### PR TITLE
Get Market events between blocks

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -4,6 +4,6 @@ CT_ADDRESS=0x36bede640D19981A82090519bC1626249984c908
 FIXED_PRODUCT_MM_FACTORY_ADDRESS=0x0fB4340432e56c014fa96286de17222822a9281b
 THE_GRAPH_CONDITIONAL_TOKENS=https://api.thegraph.com/subgraphs/name/cag/hg-rinkeby
 THE_GRAPH_OMEN=https://api.thegraph.com/subgraphs/name/davidalbela/omen-rinkeby-trade
-ETH_NODE=wss://rinkeby.infura.io/ws/v3/{INFURA_TOKEN_ID}
+ETH_NODE=https://rinkeby.infura.io/v3/{INFURA_TOKEN_ID}
 START_BLOCK=7373406
 JOB_GET_TRADE_MINUTES=60

--- a/src/events/marketEvents.js
+++ b/src/events/marketEvents.js
@@ -79,7 +79,7 @@ module.exports.watchNewMarketsEvent = async (fromBlock) => {
     if (fromBlock === 0) {
         fromBlock = await getLastBlockNumber() - 10;
     }
-    const toBlock = process.env.START_BLOCK ? 'latest' : await getLastBlockNumber() - 5;
+    const toBlock = await getLastBlockNumber() - 5;
     watchFPMMCreationEvent(fromBlock, toBlock);
     return (toBlock + 1);
 }

--- a/src/events/marketEvents.js
+++ b/src/events/marketEvents.js
@@ -42,21 +42,20 @@ const watchFPMMCreationEvent = async (fromBlock, toBlock) => {
                                     if (questions.length == 0) {
                                         console.error(`ERROR: Question for hex "${condition.questionId}" not found on contition ID ${event.returnValues.conditionIds[0]}`);
                                     } else {
-                                        message.push(questions.map(question => 
-                                            `> *<https://omen.eth.link/#/${condition.fixedProductMarketMakers}|${question.title}>*\n> *Outcomes:*`
-                                        ));
-                                        questions.forEach(question => {
-                                            if (condition.outcomeTokenMarginalPrices) {
-                                                message.push(
-                                                    question.outcomes.map((outcome, i) => 
-                                                        `> \`${(parseFloat(condition.outcomeTokenMarginalPrices[i]) * 100 )
-                                                            .toFixed(2)}%\` - ${outcome}`
-                                                    ));
-                                            } else {
-                                                message.push(
-                                                    question.outcomes.map(outcome => `> - ${outcome}`));
-                                            }
-                                        });
+                                        message.push(questions.map(question => {
+                                            return `> *<https://omen.eth.link/#/${condition.fixedProductMarketMakers}|${question.title}>*\n> *Outcomes:*`;
+                                        }));
+                                        message.push(
+                                            (questions.map(question => {
+                                                if (condition.outcomeTokenMarginalPrices) {
+                                                        return question.outcomes.map((outcome, i) =>
+                                                            `> \`${(parseFloat(condition.outcomeTokenMarginalPrices[i]) * 100 )
+                                                                .toFixed(2)}%\` - ${outcome}`
+                                                        );
+                                                } else {
+                                                        return question.outcomes.map(outcome => `> - ${outcome}`);
+                                                }
+                                        })));
                                     }
                                     message.push(`> *Collateral*: <https://${urlExplorer}/token/${event.returnValues.collateralToken}|${tokenName}>`,
                                         `> *Liquidity*: ${parseFloat(condition.scaledLiquidityParameter).toFixed(2)} ${tokenSymbol}`,

--- a/src/events/marketEvents.js
+++ b/src/events/marketEvents.js
@@ -7,69 +7,79 @@ const { getTokenName, getTokenSymbol } = require('../services/contractERC20');
 const { getQuestion } = require('../services/getQuestion');
 const { getCondition } = require('../services/getCondition');
 
+const fixedProductMarketMakerFactoryContract = getFixedProductionMarketMakerFactoryContract(web3);
+
+/**
+ * Watch `FixedProductMarketMakerCreation` events from a `FixedProductionMarketMakerFactory` contract.
+ * @param  fromBlock
+ * @param  toBlock
+ * on the `returnValues` values like an array with the `conditionIds`,
+ * and the `collateralToken`.
+ * 
+ */
+const watchFPMMCreationEvent = async (fromBlock, toBlock) => {
+    console.log(`Watching market creation events from ${fromBlock} to ${toBlock} block.`);
+
+    fixedProductMarketMakerFactoryContract.getPastEvents('FixedProductMarketMakerCreation', {
+        filter: {},
+        fromBlock,
+        toBlock,
+    }, (error, events) => {
+        events.forEach(event => {
+            (async () => {
+                const message = new Array('<!here>', '*New market created!* :tada:');
+                //TODO support conditional markets
+                Promise.all([
+                    getCondition(event.returnValues.conditionIds[0]),
+                    web3.eth.getTransaction(event.transactionHash),
+                    getTokenName(web3, event.returnValues.collateralToken), 
+                    getTokenSymbol(web3, event.returnValues.collateralToken), 
+                ])
+                    .then(([conditions, transaction, tokenName, tokenSymbol]) => {
+                        conditions.forEach(condition => {
+                            getQuestion(condition.questionId)
+                                .then((questions) => {
+                                    if (questions.length == 0) {
+                                        console.error(`ERROR: Question for hex "${condition.questionId}" not found on contition ID ${event.returnValues.conditionIds[0]}`);
+                                    } else {
+                                        message.push(questions.map(question => 
+                                            `> *<https://omen.eth.link/#/${condition.fixedProductMarketMakers}|${question.title}>*\n> *Outcomes:*`
+                                        ));
+                                        questions.forEach(question => {
+                                            if (condition.outcomeTokenMarginalPrices) {
+                                                message.push(
+                                                    question.outcomes.map((outcome, i) => 
+                                                        `> \`${(parseFloat(condition.outcomeTokenMarginalPrices[i]) * 100 )
+                                                            .toFixed(2)}%\` - ${outcome}`
+                                                    ));
+                                            } else {
+                                                message.push(
+                                                    question.outcomes.map(outcome => `> - ${outcome}`));
+                                            }
+                                        });
+                                    }
+                                    message.push(`> *Collateral*: <https://${urlExplorer}/token/${event.returnValues.collateralToken}|${tokenName}>`,
+                                        `> *Liquidity*: ${parseFloat(condition.scaledLiquidityParameter).toFixed(2)} ${tokenSymbol}`,
+                                        `> *Created by*: <https://${urlExplorer}/address/${transaction.from}|${truncate(transaction.from, 14)}>`);
+                                        // Send Slack notification
+                                    pushSlackArrayMessages(message);
+                                    console.log(event.returnValues.conditionIds[0] + ':\n' + message.join('\n') + '\n\n');
+                                });
+                        });
+                    });
+            })();
+        });
+    })
+}
+
 /**
  * Watch `FixedProductMarketMakerCreation` events from a `FixedProductionMarketMakerFactory` contract.
  */
-module.exports.watchNewMarketsEvent = async () => {
-    const fixedProductMarketMakerFactoryContract = getFixedProductionMarketMakerFactoryContract(web3);
-    const lastBlockNumber = await getLastBlockNumber() - 5;
-    
-    /**
-     * Watch `FixedProductMarketMakerCreation` events from a `FixedProductionMarketMakerFactory` contract.
-     * @param  filter filtering options to watch.
-     * @param  {process.env.START_BLOCK} fromBlock start to watch events from 
-     * the given block or from `latest` block.
-     * @param  {} error call to watch event errors.
-     * @param  {} event the event which contains market creation data
-     * on the `returnValues` values like an array with the `conditionIds`,
-     * and the `collateralToken`.
-     * 
-     */
-    fixedProductMarketMakerFactoryContract.events.FixedProductMarketMakerCreation({
-        filter: {},
-        fromBlock: process.env.START_BLOCK ? process.env.START_BLOCK : lastBlockNumber,
-    }, (error, event) => {
-        (async () => {
-            const message = new Array('<!here>', '*New market created!* :tada:');
-            //TODO support conditional markets
-            Promise.all([
-                getCondition(event.returnValues.conditionIds[0]),
-                web3.eth.getTransaction(event.transactionHash),
-                getTokenName(web3, event.returnValues.collateralToken), 
-                getTokenSymbol(web3, event.returnValues.collateralToken), 
-            ])
-                .then(([conditions, transaction, tokenName, tokenSymbol]) => {
-                    conditions.forEach(condition => {
-                        getQuestion(condition.questionId)
-                            .then((questions) => {
-                                if (questions.length == 0) {
-                                    console.error(`ERROR: Question for hex "${condition.questionId}" not found on contition ID ${event.returnValues.conditionIds[0]}`);
-                                } else {
-                                    message.push(questions.map(question => 
-                                        `> *<https://omen.eth.link/#/${condition.fixedProductMarketMakers}|${question.title}>*\n> *Outcomes:*`
-                                    ));
-                                    questions.forEach(question => {
-                                        if (condition.outcomeTokenMarginalPrices) {
-                                            message.push(
-                                                question.outcomes.map((outcome, i) => 
-                                                    `> \`${(parseFloat(condition.outcomeTokenMarginalPrices[i]) * 100 )
-                                                        .toFixed(2)}%\` - ${outcome}`
-                                                ));
-                                        } else {
-                                            message.push(
-                                                question.outcomes.map(outcome => `> - ${outcome}`));
-                                        }
-                                    });
-                                }
-                                message.push(`> *Collateral*: <https://${urlExplorer}/token/${event.returnValues.collateralToken}|${tokenName}>`,
-                                    `> *Liquidity*: ${parseFloat(condition.scaledLiquidityParameter).toFixed(2)} ${tokenSymbol}`,
-                                    `> *Created by*: <https://${urlExplorer}/address/${transaction.from}|${truncate(transaction.from, 14)}>`);
-                                    // Send Slack notification
-                                pushSlackArrayMessages(message);
-                                console.log(event.returnValues.conditionIds[0] + ':\n' + message.join('\n') + '\n\n');
-                            });
-                    });
-                });
-        })();
-    });
+module.exports.watchNewMarketsEvent = async (fromBlock) => {
+    if (fromBlock === 0) {
+        fromBlock = await getLastBlockNumber() - 10;
+    }
+    const toBlock = process.env.START_BLOCK ? 'latest' : await getLastBlockNumber() - 5;
+    watchFPMMCreationEvent(fromBlock, toBlock);
+    return toBlock;
 }

--- a/src/events/marketEvents.js
+++ b/src/events/marketEvents.js
@@ -81,5 +81,5 @@ module.exports.watchNewMarketsEvent = async (fromBlock) => {
     }
     const toBlock = process.env.START_BLOCK ? 'latest' : await getLastBlockNumber() - 5;
     watchFPMMCreationEvent(fromBlock, toBlock);
-    return toBlock;
+    return (toBlock + 1);
 }

--- a/src/index.js
+++ b/src/index.js
@@ -23,11 +23,18 @@ const startMessage = `Conditional Tokens bot \`${version}\` was started.`;
 pushSlackMessage(startMessage);
 console.log(startMessage);
 
+const jobTime = process.env.JOB_GET_TRADE_MINUTES ? process.env.JOB_GET_TRADE_MINUTES : 5;
+
 // Watch new market created events
-watchNewMarketsEvent();
+let lastUsedBlock = 0
+schedule.scheduleJob(`*/${jobTime} * * * *`, function() {
+    const fromBlock = lastUsedBlock ? lastUsedBlock : 0;
+    watchNewMarketsEvent(fromBlock).then(toBlock => {
+        lastUsedBlock = toBlock;
+    });
+});
 
 // Look for trade events every minute
-const jobTime = process.env.JOB_GET_TRADE_MINUTES ? process.env.JOB_GET_TRADE_MINUTES : 5;
 console.log(`Configure get trades job for every ${jobTime} minutes`);
 const pastTimeInSeconds = jobTime * 60;
 

--- a/src/utils/web3.js
+++ b/src/utils/web3.js
@@ -1,12 +1,7 @@
 const Web3 = require('web3');
 
 // Create a web3 instance
-const web3 = new Web3(new Web3.providers.WebsocketProvider(process.env.ETH_NODE));
-
-// Check websocket connection event
-web3._provider.on('end', (eventObj) => {
-    console.error('The websocket was Disconnected');
-});
+const web3 = new Web3(new Web3.providers.HttpProvider(process.env.ETH_NODE));
 
 const getLastBlockNumber = async () => {
     return web3.eth.getBlockNumber();


### PR DESCRIPTION
Add `watchFPMMCreationEvent` function to get past events between
`fromBlock` to `toBlock` block number.

Add a new job for `watchNewMarketsEvent` from started block `fromBlock`.

Resolves: #24