### PR TITLE
Add watch event for market is resolved

### DIFF
--- a/src/events/marketEvents.js
+++ b/src/events/marketEvents.js
@@ -2,22 +2,23 @@ const { urlExplorer } = require('../config/constants');
 const { truncate } = require('../utils/utils');
 const { pushSlackArrayMessages } = require('../utils/slack');
 const { web3, getLastBlockNumber } = require('../utils/web3');
-const { getFixedProductionMarketMakerFactoryContract } = require('../services/contractEvents');
+const { getFixedProductionMarketMakerFactoryContract, getconditionalTokensContract } = require('../services/contractEvents');
 const { getTokenName, getTokenSymbol } = require('../services/contractERC20');
 const { getQuestion } = require('../services/getQuestion');
 const { getCondition } = require('../services/getCondition');
 
 const fixedProductMarketMakerFactoryContract = getFixedProductionMarketMakerFactoryContract(web3);
+const conditionalTokensContract = getconditionalTokensContract(web3);
 
 /**
- * Watch `FixedProductMarketMakerCreation` events from a `FixedProductionMarketMakerFactory` contract.
+ * Get `FixedProductMarketMakerCreation` events from a `FixedProductionMarketMakerFactory` contract.
  * @param  fromBlock
  * @param  toBlock
  * on the `returnValues` values like an array with the `conditionIds`,
  * and the `collateralToken`.
  * 
  */
-const watchFPMMCreationEvent = async (fromBlock, toBlock) => {
+const getFPMMCreationEvent = async (fromBlock, toBlock) => {
     console.log(`Watching market creation events from ${fromBlock} to ${toBlock} block.`);
 
     fixedProductMarketMakerFactoryContract.getPastEvents('FixedProductMarketMakerCreation', {
@@ -72,13 +73,68 @@ const watchFPMMCreationEvent = async (fromBlock, toBlock) => {
 }
 
 /**
+ * Get `ConditionResolution` events from a `ConditionalTokens` contract.
+ * @param  fromBlock
+ * @param  toBlock
+ * on the `returnValues` returns the following parameters:
+ * bytes32 indexed `conditionId` the condition id of the market.
+ * address indexed `oracle` the oracle that calls the function `reportPayouts`.
+ * bytes32 indexed `questionId` the question id the oracle is answering for.
+ * uint `outcomeSlotCount` the number of the outcomes reported.
+ * uint[] `payoutNumerators` the oracle's answer reported.
+ */
+const getResolvedMarketsEvents = async (fromBlock, toBlock) => {
+    console.log(`Watching condition resolution events from ${fromBlock} to ${toBlock} block.`);
+
+    conditionalTokensContract.getPastEvents('ConditionResolution', {
+        filter: {},
+        fromBlock,
+        toBlock,
+    }, (error, events) => {
+        events.forEach(event => {
+            (async () => {
+                const questions = await getQuestion(event.returnValues.questionId);
+                if (questions.length > 0) {
+                    const message = new Array(
+                        '*Market resolved*',
+                        `*Title:* <https://omen.eth.link/#/${questions[0].indexedFixedProductMarketMakers}|${questions[0].title}>`,
+                        `*Answer:*`,
+                    );
+                    event.returnValues.payoutNumerators.forEach((payout, index) => {
+                        if(payout === '1') {
+                            message.push(`- ${questions[0].outcomes[index]}`);
+                        }
+                    });
+                    pushSlackArrayMessages(message);
+                    console.log(event.returnValues.questionId + ':\n' + message.join('\n') + '\n\n');
+                } else {
+                    console.error(`ERROR: Question for hex "${event.returnValues.questionId}" not found on Omen subgraph.`);
+                }
+            })();
+        });
+    });
+}
+
+/**
  * Watch `FixedProductMarketMakerCreation` events from a `FixedProductionMarketMakerFactory` contract.
  */
-module.exports.watchNewMarketsEvent = async (fromBlock) => {
+module.exports.watchCreationMarketsEvent = async (fromBlock) => {
     if (fromBlock === 0) {
         fromBlock = await getLastBlockNumber() - 10;
     }
     const toBlock = await getLastBlockNumber() - 5;
-    watchFPMMCreationEvent(fromBlock, toBlock);
+    getFPMMCreationEvent(fromBlock, toBlock);
+    return (toBlock + 1);
+}
+
+/**
+ * Watch `FixedProductMarketMakerCreation` events from a `FixedProductionMarketMakerFactory` contract.
+ */
+module.exports.watchResolvedMarketsEvent = async (fromBlock) => {
+    if (fromBlock === 0) {
+        fromBlock = await getLastBlockNumber() - 100000;
+    }
+    const toBlock = await getLastBlockNumber() - 5;
+    getResolvedMarketsEvents(fromBlock, toBlock);
     return (toBlock + 1);
 }

--- a/src/events/marketEvents.js
+++ b/src/events/marketEvents.js
@@ -117,6 +117,7 @@ const getResolvedMarketsEvents = async (fromBlock, toBlock) => {
 
 /**
  * Watch `FixedProductMarketMakerCreation` events from a `FixedProductionMarketMakerFactory` contract.
+ * @param fromBlock
  */
 module.exports.watchCreationMarketsEvent = async (fromBlock) => {
     if (fromBlock === 0) {
@@ -129,10 +130,11 @@ module.exports.watchCreationMarketsEvent = async (fromBlock) => {
 
 /**
  * Watch `FixedProductMarketMakerCreation` events from a `FixedProductionMarketMakerFactory` contract.
+ * @param fromBlock
  */
 module.exports.watchResolvedMarketsEvent = async (fromBlock) => {
     if (fromBlock === 0) {
-        fromBlock = await getLastBlockNumber() - 100000;
+        fromBlock = await getLastBlockNumber() - 10;
     }
     const toBlock = await getLastBlockNumber() - 5;
     getResolvedMarketsEvents(fromBlock, toBlock);

--- a/src/index.js
+++ b/src/index.js
@@ -4,7 +4,7 @@ const schedule = require('node-schedule');
 const packageJson = require('../package.json');
 const { port, jobTime } = require('./config');
 const { pushSlackMessage } = require('./utils/slack');
-const { watchNewMarketsEvent } = require('./events/marketEvents');
+const { watchCreationMarketsEvent, watchResolvedMarketsEvent } = require('./events/marketEvents');
 const { findTradeEvents } = require('./events/tradeEvents');
 const { findLiquidityEvents } = require('./events/liquidityEvents');
 
@@ -24,13 +24,15 @@ const startMessage = `Conditional Tokens bot \`${version}\` was started.`;
 pushSlackMessage(startMessage);
 console.log(startMessage);
 
-// Watch new market created events
+// Watch new market created and resolved market events
 let lastUsedBlock = 0;
 schedule.scheduleJob(`*/${jobTime} * * * *`, function() {
     const fromBlock = lastUsedBlock ? lastUsedBlock : 0;
-    watchNewMarketsEvent(fromBlock).then(toBlock => {
+    watchCreationMarketsEvent(fromBlock).then(toBlock => {
         lastUsedBlock = toBlock;
     });
+    // Watch resolved markets
+    watchResolvedMarketsEvent(fromBlock);
 });
 
 // Look for trade events every minute

--- a/src/services/getQuestion.js
+++ b/src/services/getQuestion.js
@@ -6,7 +6,7 @@ const fetch = require('node-fetch');
  * @returns a Question records list.
  */
 module.exports.getQuestion = (questionId) => {
-  const jsonQuery = { query: `{  questions(  where: {    id: \"${questionId}\"  }  ) { id outcomes title category }}` }
+  const jsonQuery = { query: `{  questions(  where: {    id: \"${questionId}\"  }  ) { id outcomes title indexedFixedProductMarketMakers { id }}}` }
 
   return fetch(process.env.THE_GRAPH_OMEN, {
     headers: { 'Content-Type': 'application/json' },
@@ -19,11 +19,11 @@ module.exports.getQuestion = (questionId) => {
       if(json.errors) {
         throw new Error(json.errors.map(error => error.message));
       }
-      return json.data.questions && json.data.questions.map(question => 
+      return json.data.questions && json.data.questions.map(question =>
         ({
           title: question.title,
           outcomes: question.outcomes,
-          category: question.category,
+          indexedFixedProductMarketMakers: (question.indexedFixedProductMarketMakers.length > 0) ? question.indexedFixedProductMarketMakers[0].id : null,
         })
       );
     });


### PR DESCRIPTION
- Add `getResolvedMarketsEvents` method to get event from Conditional
Tokens smart contract when `ConditionResolution` is emitted.
- Rename method `watchFPMMCreationEvent` to `getFPMMCreationEvent` and
exported method `watchNewMarketsEvent` to `watchCreationMarketsEvent`.
- Remove then from Promise.all on `getFPMMCreationEvent`.

Resolves: #32
