### PR TITLE
Add find markets ready to be resolved

### DIFF
--- a/src/events/marketEvents.js
+++ b/src/events/marketEvents.js
@@ -4,7 +4,7 @@ const { pushSlackArrayMessages } = require('../utils/slack');
 const { web3, getLastBlockNumber } = require('../utils/web3');
 const { getFixedProductionMarketMakerFactoryContract, getconditionalTokensContract } = require('../services/contractEvents');
 const { getTokenName, getTokenSymbol } = require('../services/contractERC20');
-const { getQuestion, getQuestionByOpeningTimestamp } = require('../services/getQuestion');
+const { getQuestion, getQuestionByOpeningTimestamp, findQuestionByIsPendingArbitration } = require('../services/getQuestion');
 const { getCondition } = require('../services/getCondition');
 
 const fixedProductMarketMakerFactoryContract = getFixedProductionMarketMakerFactoryContract(web3);
@@ -153,6 +153,24 @@ module.exports.findMarketReadyByQuestionOpeningTimestamp = async (timestamp, pas
     questions.forEach(question => {
         const message = new Array(
             '*Market ready for resolution*',
+            `*Title:* <https://omen.eth.link/#/${question.indexedFixedProductMarketMakers}|${question.title}>`,
+        );
+        pushSlackArrayMessages(message);
+        console.log(question.id + ':\n' + message.join('\n') + '\n\n');
+    });
+}
+
+/**
+ * Look for Question records where `isPendingArbitration` is true 
+ * and the field `openingTimestamp` is greather or equals than `timestamp`
+ * @param timestamp timestamp in seconds to look for Question records.
+ */
+module.exports.findMarketIsPendingArbitration = async (timestamp) => {
+    console.log(`Looking for markets on arbitration after openingTimestamp ${timestamp}`);
+    const questions = await findQuestionByIsPendingArbitration(timestamp, 20);
+    questions.forEach(question => {
+        const message = new Array(
+            '*Market is in arbitration*',
             `*Title:* <https://omen.eth.link/#/${question.indexedFixedProductMarketMakers}|${question.title}>`,
         );
         pushSlackArrayMessages(message);

--- a/src/events/marketEvents.js
+++ b/src/events/marketEvents.js
@@ -2,22 +2,23 @@ const { urlExplorer } = require('../config/constants');
 const { truncate } = require('../utils/utils');
 const { pushSlackArrayMessages } = require('../utils/slack');
 const { web3, getLastBlockNumber } = require('../utils/web3');
-const { getFixedProductionMarketMakerFactoryContract } = require('../services/contractEvents');
+const { getFixedProductionMarketMakerFactoryContract, getconditionalTokensContract } = require('../services/contractEvents');
 const { getTokenName, getTokenSymbol } = require('../services/contractERC20');
 const { getQuestion } = require('../services/getQuestion');
 const { getCondition } = require('../services/getCondition');
 
 const fixedProductMarketMakerFactoryContract = getFixedProductionMarketMakerFactoryContract(web3);
+const conditionalTokensContract = getconditionalTokensContract(web3);
 
 /**
- * Watch `FixedProductMarketMakerCreation` events from a `FixedProductionMarketMakerFactory` contract.
+ * Get `FixedProductMarketMakerCreation` events from a `FixedProductionMarketMakerFactory` contract.
  * @param  fromBlock
  * @param  toBlock
  * on the `returnValues` values like an array with the `conditionIds`,
  * and the `collateralToken`.
  * 
  */
-const watchFPMMCreationEvent = async (fromBlock, toBlock) => {
+const getFPMMCreationEvent = async (fromBlock, toBlock) => {
     console.log(`Watching market creation events from ${fromBlock} to ${toBlock} block.`);
 
     fixedProductMarketMakerFactoryContract.getPastEvents('FixedProductMarketMakerCreation', {
@@ -72,13 +73,68 @@ const watchFPMMCreationEvent = async (fromBlock, toBlock) => {
 }
 
 /**
+ * Get `ConditionResolution` events from a `ConditionalTokens` contract.
+ * @param  fromBlock
+ * @param  toBlock
+ * on the `returnValues` returns the following parameters:
+ * bytes32 indexed `conditionId` the condition id of the market.
+ * address indexed `oracle` the oracle that calls the function `reportPayouts`.
+ * bytes32 indexed `questionId` the question id the oracle is answering for.
+ * uint `outcomeSlotCount` the number of the outcomes reported.
+ * uint[] `payoutNumerators` the oracle's answer reported.
+ */
+const getResolvedMarketsEvents = async (fromBlock, toBlock) => {
+    console.log(`Watching condition resolution events from ${fromBlock} to ${toBlock} block.`);
+
+    conditionalTokensContract.getPastEvents('ConditionResolution', {
+        filter: {},
+        fromBlock,
+        toBlock,
+    }, (error, events) => {
+        events.forEach(event => {
+            (async () => {
+                const questions = await getQuestion(event.returnValues.questionId);
+                if (questions.length > 0) {
+                    const message = new Array(
+                        '*Market resolved*',
+                        `*Title:* <https://omen.eth.link/#/${questions[0].indexedFixedProductMarketMakers}|${questions[0].title}>`,
+                        `*Answer:*`,
+                    );
+                    event.returnValues.payoutNumerators.forEach((payout, index) => {
+                        if(payout === '1') {
+                            message.push(`- ${questions[0].outcomes[index]}`);
+                        }
+                    });
+                    pushSlackArrayMessages(message);
+                    console.log(event.returnValues.questionId + ':\n' + message.join('\n') + '\n\n');
+                } else {
+                    console.error(`ERROR: Question for hex "${event.returnValues.questionId}" not found on Omen subgraph.`);
+                }
+            })();
+        });
+    });
+}
+
+/**
  * Watch `FixedProductMarketMakerCreation` events from a `FixedProductionMarketMakerFactory` contract.
  */
-module.exports.watchNewMarketsEvent = async (fromBlock) => {
+module.exports.watchCreationMarketsEvent = async (fromBlock) => {
     if (fromBlock === 0) {
         fromBlock = await getLastBlockNumber() - 10;
     }
     const toBlock = await getLastBlockNumber() - 5;
-    watchFPMMCreationEvent(fromBlock, toBlock);
+    getFPMMCreationEvent(fromBlock, toBlock);
+    return (toBlock + 1);
+}
+
+/**
+ * Watch `FixedProductMarketMakerCreation` events from a `FixedProductionMarketMakerFactory` contract.
+ */
+module.exports.watchResolvedMarketsEvent = async (fromBlock) => {
+    if (fromBlock === 0) {
+        fromBlock = await getLastBlockNumber() - 100000;
+    }
+    const toBlock = await getLastBlockNumber() - 5;
+    getResolvedMarketsEvents(fromBlock, toBlock);
     return (toBlock + 1);
 }

--- a/src/events/marketEvents.js
+++ b/src/events/marketEvents.js
@@ -117,6 +117,7 @@ const getResolvedMarketsEvents = async (fromBlock, toBlock) => {
 
 /**
  * Watch `FixedProductMarketMakerCreation` events from a `FixedProductionMarketMakerFactory` contract.
+ * @param fromBlock
  */
 module.exports.watchCreationMarketsEvent = async (fromBlock) => {
     if (fromBlock === 0) {
@@ -129,10 +130,11 @@ module.exports.watchCreationMarketsEvent = async (fromBlock) => {
 
 /**
  * Watch `FixedProductMarketMakerCreation` events from a `FixedProductionMarketMakerFactory` contract.
+ * @param fromBlock
  */
 module.exports.watchResolvedMarketsEvent = async (fromBlock) => {
     if (fromBlock === 0) {
-        fromBlock = await getLastBlockNumber() - 100000;
+        fromBlock = await getLastBlockNumber() - 10;
     }
     const toBlock = await getLastBlockNumber() - 5;
     getResolvedMarketsEvents(fromBlock, toBlock);

--- a/src/index.js
+++ b/src/index.js
@@ -4,7 +4,7 @@ const schedule = require('node-schedule');
 const packageJson = require('../package.json');
 const { port, jobTime } = require('./config');
 const { pushSlackMessage } = require('./utils/slack');
-const { watchNewMarketsEvent } = require('./events/marketEvents');
+const { watchCreationMarketsEvent, watchResolvedMarketsEvent } = require('./events/marketEvents');
 const { findTradeEvents } = require('./events/tradeEvents');
 const { findLiquidityEvents } = require('./events/liquidityEvents');
 
@@ -24,13 +24,15 @@ const startMessage = `Conditional Tokens bot \`${version}\` was started.`;
 pushSlackMessage(startMessage);
 console.log(startMessage);
 
-// Watch new market created events
+// Watch new market created and resolved market events
 let lastUsedBlock = 0;
 schedule.scheduleJob(`*/${jobTime} * * * *`, function() {
     const fromBlock = lastUsedBlock ? lastUsedBlock : 0;
-    watchNewMarketsEvent(fromBlock).then(toBlock => {
+    watchCreationMarketsEvent(fromBlock).then(toBlock => {
         lastUsedBlock = toBlock;
     });
+    // Watch resolved markets
+    watchResolvedMarketsEvent(fromBlock);
 });
 
 // Look for trade events every minute

--- a/src/index.js
+++ b/src/index.js
@@ -4,7 +4,9 @@ const schedule = require('node-schedule');
 const packageJson = require('../package.json');
 const { port, jobTime } = require('./config');
 const { pushSlackMessage } = require('./utils/slack');
-const { watchCreationMarketsEvent, watchResolvedMarketsEvent } = require('./events/marketEvents');
+const { watchCreationMarketsEvent, 
+    watchResolvedMarketsEvent, 
+    findMarketReadyByQuestionOpeningTimestamp } = require('./events/marketEvents');
 const { findTradeEvents } = require('./events/tradeEvents');
 const { findLiquidityEvents } = require('./events/liquidityEvents');
 
@@ -35,8 +37,7 @@ schedule.scheduleJob(`*/${jobTime} * * * *`, function() {
     watchResolvedMarketsEvent(fromBlock);
 });
 
-// Look for trade events every minute
-console.log(`Configure to find trade and liquidity events for every ${jobTime} minutes`);
+console.log(`Configure to find trade, liquidity events and market ready to be resolved for every ${jobTime} minutes`);
 const pastTimeInSeconds = jobTime * 60;
 
 const timestamp = Math.floor(Date.now() / 1000);
@@ -46,4 +47,6 @@ schedule.scheduleJob(`*/${jobTime} * * * *`, function() {
     const timestamp = Math.floor(Date.now() / 1000);
     findTradeEvents(timestamp, pastTimeInSeconds);
     findLiquidityEvents(timestamp, pastTimeInSeconds);
+    // Find markets ready to be resolved
+    findMarketReadyByQuestionOpeningTimestamp(timestamp, pastTimeInSeconds);
 });

--- a/src/index.js
+++ b/src/index.js
@@ -6,7 +6,8 @@ const { port, jobTime } = require('./config');
 const { pushSlackMessage } = require('./utils/slack');
 const { watchCreationMarketsEvent, 
     watchResolvedMarketsEvent, 
-    findMarketReadyByQuestionOpeningTimestamp } = require('./events/marketEvents');
+    findMarketReadyByQuestionOpeningTimestamp,
+    findMarketIsPendingArbitration } = require('./events/marketEvents');
 const { findTradeEvents } = require('./events/tradeEvents');
 const { findLiquidityEvents } = require('./events/liquidityEvents');
 
@@ -49,4 +50,6 @@ schedule.scheduleJob(`*/${jobTime} * * * *`, function() {
     findLiquidityEvents(timestamp, pastTimeInSeconds);
     // Find markets ready to be resolved
     findMarketReadyByQuestionOpeningTimestamp(timestamp, pastTimeInSeconds);
+    // Find markets is pending arbitration
+    findMarketIsPendingArbitration(timestamp);
 });

--- a/src/services/getQuestion.js
+++ b/src/services/getQuestion.js
@@ -6,7 +6,7 @@ const fetch = require('node-fetch');
  * @returns a Question records list.
  */
 module.exports.getQuestion = (questionId) => {
-  const jsonQuery = { query: `{  questions(  where: {    id: \"${questionId}\"  }  ) { id outcomes title category }}` }
+  const jsonQuery = { query: `{  questions(  where: {    id: \"${questionId}\"  }  ) { id outcomes title indexedFixedProductMarketMakers { id }}}` }
 
   return fetch(process.env.THE_GRAPH_OMEN, {
     headers: { 'Content-Type': 'application/json' },
@@ -19,11 +19,11 @@ module.exports.getQuestion = (questionId) => {
       if(json.errors) {
         throw new Error(json.errors.map(error => error.message));
       }
-      return json.data.questions && json.data.questions.map(question => 
+      return json.data.questions && json.data.questions.map(question =>
         ({
           title: question.title,
           outcomes: question.outcomes,
-          category: question.category,
+          indexedFixedProductMarketMakers: (question.indexedFixedProductMarketMakers.length > 0) ? question.indexedFixedProductMarketMakers[0].id : null,
         })
       );
     });

--- a/src/services/getQuestion.js
+++ b/src/services/getQuestion.js
@@ -64,3 +64,36 @@ module.exports.getQuestionByOpeningTimestamp = (openingTimestamp, seconds, limit
       );
     });
 }
+
+/**
+ * Find questions where `isPendingArbitration` field is `true` on
+ * the closing date giving by the field `openingTimestamp`
+ * is greather or equals than `openingTimestamp` timestamp.
+ * @param openingTimestamp timestamp in seconds.
+ * @param limit number of first Question elements to retrieve.
+ * @returns a Question records list.
+ */
+module.exports.findQuestionByIsPendingArbitration = (openingTimestamp, limit) => {
+  const jsonQuery = { query: `{  questions(first: ${limit}, where: { isPendingArbitration: true, openingTimestamp_gte: \"${openingTimestamp}\"}) { id outcomes title indexedFixedProductMarketMakers { id }}}` }
+
+  return fetch(process.env.THE_GRAPH_OMEN, {
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(jsonQuery),
+    method: "POST",
+  })
+    .then(res => res.json())
+    .catch(error => console.error('Error:', error))
+    .then(json => {
+      if(json.errors) {
+        throw new Error(json.errors.map(error => error.message));
+      }
+      return json.data.questions && json.data.questions.map(question =>
+        ({
+          id: question.id,
+          title: question.title,
+          outcomes: question.outcomes,
+          indexedFixedProductMarketMakers: (question.indexedFixedProductMarketMakers.length > 0) ? question.indexedFixedProductMarketMakers[0].id : null,
+        })
+      );
+    });
+}

--- a/src/services/getTrade.js
+++ b/src/services/getTrade.js
@@ -3,12 +3,12 @@ const fetch = require('node-fetch');
 /**
  * Look for last FPMM trade records ordered by `creationTimestamp` in 
  * descendent order direction.
- * @param  {} timestamp timestamp in seconds to look for FPMM trade records 
+ * @param creationTimestamp timestamp in seconds to look for FPMM trade records 
  * where `creationTimestamp` field is less or equal than `timestamp`.
- * @param  {} pastTimeInSeconds number of seconds to filter the last FPMM 
+ * @param seconds number of seconds to filter the last FPMM 
  * trade records where `creationTimestamp` field is greather than 
- * `timestamp` minus `pastTimeInSeconds`.
- * @limit number of first Trade elements to retrieve.
+ * `creationTimestamp - seconds`.
+ * @param limit number of first Trade elements to retrieve.
  * @returns a FPMM Trade list with the ffpm addres and the outcomes.
  */
 module.exports.getTrade = (creationTimestamp, seconds, limit) => {


### PR DESCRIPTION
- Add `getQuestionByOpeningTimestamp` GQL query to find question
  where the closing date giving by the field `openingTimestamp`.
- Add event `findMarketReadyByQuestionOpeningTimestamp` on marketEvents
  to look for Markets ready to be resolved by the `openingTimestamp`
  value of the queistion of the market.

Resolves: #27
