### PR TITLE
Fix query get old FPMMTrade

### DIFF
--- a/src/events/tradeEvents.js
+++ b/src/events/tradeEvents.js
@@ -27,7 +27,7 @@ module.exports.findTradeEvents = async (timestamp, pastTimeInSeconds) => {
         if (trade.collateralAmountUSD > 1000.00) {
             message.push('<!here>');
         }
-        const oldOdds = oldTrade ? parseFloat(oldTrade.outcomeTokenMarginalPrices[trade.outcomeIndex] * 100 ).toFixed(2) : '0.00';
+        const oldOdds = (oldTrade && oldTrade.outcomeTokenMarginalPrices) ? parseFloat(oldTrade.outcomeTokenMarginalPrices[trade.outcomeIndex] * 100 ).toFixed(2) : '0.00';
         const outcome = trade.outcomes ? trade.outcomes[trade.outcomeIndex] : trade.outcomeIndex;
         message.push(`> ${amount} <https://${urlExplorer}/token/${trade.collateralToken}|${tokenName}> of *${outcome}* ${type} in "<https://omen.eth.link/#/${trade.fpmm}|${trade.title}>".`,
             `> Outcome odds: ${oldOdds}% --> ${odds}%`,

--- a/src/events/tradeEvents.js
+++ b/src/events/tradeEvents.js
@@ -15,32 +15,26 @@ const { getTrade, getOldTrade } = require('../services/getTrade');
  */
 module.exports.findTradeEvents = async (timestamp, pastTimeInSeconds) => {
     console.log(`Looking for new trades at ${timestamp}`);
-    getTrade(timestamp, pastTimeInSeconds, 20)
-        .then(trades => {
-            trades.forEach(trade => {
-                const message = new Array();
-                const type = (trade.type === 'Buy') ? 'purchased' : 'sold';
-                const odds = parseFloat(trade.outcomeTokenMarginalPrices[trade.outcomeIndex] * 100 ).toFixed(2);
-                Promise.all([
-                    getTokenName(web3, trade.collateralToken),
-                    getTokenDecimals(web3, trade.collateralToken),
-                    getOldTrade(trade.id),
-                ])
-                    .then(([tokenName, decimals, oldTrade]) => {
-                        const amount = parseFloat(trade.collateralAmount / 10**decimals).toFixed(2);
-                        if (trade.collateralAmountUSD > 1000.00) {
-                            message.push('<!here>');
-                        }
-                        const oldOdds = oldTrade ? parseFloat(oldTrade.outcomeTokenMarginalPrices[trade.outcomeIndex] * 100 ).toFixed(2) : '0.00';
-                        const outcome = trade.outcomes ? trade.outcomes[trade.outcomeIndex] : trade.outcomeIndex;
-                        message.push(`> ${amount} <https://${urlExplorer}/token/${trade.collateralToken}|${tokenName}> of *${outcome}* ${type} in "<https://omen.eth.link/#/${trade.fpmm}|${trade.title}>".`,
-                            `> Outcome odds: ${oldOdds}% --> ${odds}%`,
-                            `> *Created by*: <https://omen.eth.link/#/${trade.creator}|${truncate(trade.creator, 14)}>`,
-                        );
-                        // Send Slack notification
-                        pushSlackArrayMessages(message);
-                        console.log(message.join('\n') + '\n');
-                    });
-            });
-        });
+    const trades = await getTrade(timestamp, pastTimeInSeconds, 20)
+    trades.forEach(async trade => {
+        const message = new Array();
+        const type = (trade.type === 'Buy') ? 'purchased' : 'sold';
+        const odds = parseFloat(trade.outcomeTokenMarginalPrices[trade.outcomeIndex] * 100 ).toFixed(2);
+        const tokenName = await getTokenName(web3, trade.collateralToken);
+        const decimals = await getTokenDecimals(web3, trade.collateralToken);
+        const oldTrade = await getOldTrade(trade.fpmm, trade.id, trade.creationTimestamp);
+        const amount = parseFloat(trade.collateralAmount / 10**decimals).toFixed(2);
+        if (trade.collateralAmountUSD > 1000.00) {
+            message.push('<!here>');
+        }
+        const oldOdds = oldTrade ? parseFloat(oldTrade.outcomeTokenMarginalPrices[trade.outcomeIndex] * 100 ).toFixed(2) : '0.00';
+        const outcome = trade.outcomes ? trade.outcomes[trade.outcomeIndex] : trade.outcomeIndex;
+        message.push(`> ${amount} <https://${urlExplorer}/token/${trade.collateralToken}|${tokenName}> of *${outcome}* ${type} in "<https://omen.eth.link/#/${trade.fpmm}|${trade.title}>".`,
+            `> Outcome odds: ${oldOdds}% --> ${odds}%`,
+            `> *Created by*: <https://omen.eth.link/#/${trade.creator}|${truncate(trade.creator, 14)}>`,
+        );
+        // Send Slack notification
+        pushSlackArrayMessages(message);
+        console.log(message.join('\n') + '\n');
+    });
 }

--- a/src/events/tradeEvents.js
+++ b/src/events/tradeEvents.js
@@ -16,7 +16,7 @@ const { getTrade, getOldTrade } = require('../services/getTrade');
 module.exports.findTradeEvents = async (timestamp, pastTimeInSeconds) => {
     console.log(`Looking for new trades at ${timestamp}`);
     const trades = await getTrade(timestamp, pastTimeInSeconds, 20)
-    trades.forEach(async trade => {
+    for (const trade of trades) {
         const message = new Array();
         const type = (trade.type === 'Buy') ? 'purchased' : 'sold';
         const odds = parseFloat(trade.outcomeTokenMarginalPrices[trade.outcomeIndex] * 100 ).toFixed(2);
@@ -36,5 +36,5 @@ module.exports.findTradeEvents = async (timestamp, pastTimeInSeconds) => {
         // Send Slack notification
         pushSlackArrayMessages(message);
         console.log(message.join('\n') + '\n');
-    });
+    }
 }

--- a/src/services/getTrade.js
+++ b/src/services/getTrade.js
@@ -49,12 +49,16 @@ module.exports.getTrade = (creationTimestamp, seconds, limit) => {
 
 /**
  * Look for the fist last FPMM trade record ordered by `creationTimestamp` in 
- * descendent order direction where `id` is NOT the given `notId`.
- * @param  {} notId the `id` hex value to filter by not this given value.
+ * descendent order direction where market id is the given `fpmmId`,
+ * the trade id is NOT the given `notTradeId`, and
+ * the creationTimestamp is less than `creationTimestamp`.
+ * @param fpmmId the `id` of the market.
+ * @param notTradeId the `id` hex value to filter by not this given value.
+ * @param creationTimestamp the creation timestamp is before `creationTimestamp`.
  * @returns a last FPMM trade record.
  */
-module.exports.getOldTrade = (notId) => {
-  const jsonQuery = { query: `{fpmmTrades(first: 1, where: { id_not: \"${notId}\" }, orderBy: creationTimestamp, orderDirection: desc) { id fpmm { id outcomeTokenMarginalPrices } }}` }
+module.exports.getOldTrade = (fpmmId, notTradeId, creationTimestamp) => {
+  const jsonQuery = { query: `{fpmmTrades(first: 1, where: { fpmm: \"${fpmmId}\", id_not: \"${notTradeId}\", creationTimestamp_lt: \"${creationTimestamp}\" }, orderBy: creationTimestamp, orderDirection: desc) { id fpmm { id outcomeTokenMarginalPrices } }}` }
 
   const promise = fetch(process.env.THE_GRAPH_OMEN, {
     headers: {'Content-Type': 'application/json'},


### PR DESCRIPTION
- Add `fpmmId` and `creationTimestamp` to getOldTrade query to find the
old trades before the current trade and get the right outcomeTokenMarginalPrices.
- Remove Promise.all and then from `findTradeEvents` event.

Resolves: #39