### PR TITLE
Add outcomeTokenMarginalPrice FPMMTrade fields

### DIFF
--- a/src/events/liquidityEvents.js
+++ b/src/events/liquidityEvents.js
@@ -30,9 +30,11 @@ module.exports.findLiquidityEvents = async (timestamp, pastTimeInSeconds) => {
                         const amount = parseFloat(liquidity.collateralTokenAmount / 10**decimals).toFixed(2);
                         message.push(`> ${amount} <${urlExplorer}/token/${liquidity.collateralToken}|${tokenName}> of liquidity ${type} in "*<https://omen.eth.link/#/${liquidity.fpmm}|${liquidity.title}>*", total liquidity is now *${liquidity.scaledLiquidityParameter} ${tokenSymbol}*.`,
                             `> *Created by*: <https://omen.eth.link/#/${liquidity.funder}|${truncate(liquidity.funder, 14)}>`,
+                            `> *Transaction*: <https://${urlExplorer}/tx/${liquidity.transactionHash}|${truncate(liquidity.transactionHash, 14)}>`,
                         );
                         // Send Slack notification
                         pushSlackArrayMessages(message);
+                        console.log(liquidity.creationTimestamp);
                         console.log(message.join('\n') + '\n');
                     });
             });

--- a/src/events/tradeEvents.js
+++ b/src/events/tradeEvents.js
@@ -36,6 +36,7 @@ module.exports.findTradeEvents = async (timestamp, pastTimeInSeconds) => {
         );
         // Send Slack notification
         pushSlackArrayMessages(message);
+        console.log(trade.creationTimestamp);
         console.log(message.join('\n') + '\n');
     }
 }

--- a/src/events/tradeEvents.js
+++ b/src/events/tradeEvents.js
@@ -20,19 +20,19 @@ module.exports.findTradeEvents = async (timestamp, pastTimeInSeconds) => {
     for (const trade of trades) {
         const message = new Array();
         const type = (trade.type === 'Buy') ? 'purchased' : 'sold';
-        const odds = parseFloat(trade.outcomeTokenMarginalPrices[trade.outcomeIndex] * 100 ).toFixed(2);
+        const odds = parseFloat(trade.outcomeTokenMarginalPrice * 100).toFixed(2);
+        const oldOdds = parseFloat(trade.oldOutcomeTokenMarginalPrice * 100).toFixed(2);
         const tokenName = await getTokenName(web3, trade.collateralToken);
         const decimals = await getTokenDecimals(web3, trade.collateralToken);
-        const oldTrade = await getOldTrade(trade.fpmm, trade.id, trade.creationTimestamp);
         const amount = parseFloat(trade.collateralAmount / 10**decimals).toFixed(2);
         if (trade.collateralAmountUSD > 1000.00) {
             message.push('<!here>');
         }
-        const oldOdds = (oldTrade && oldTrade.outcomeTokenMarginalPrices) ? parseFloat(oldTrade.outcomeTokenMarginalPrices[trade.outcomeIndex] * 100 ).toFixed(2) : '0.00';
         const outcome = trade.outcomes ? trade.outcomes[trade.outcomeIndex] : trade.outcomeIndex;
         message.push(`> ${amount} <${urlExplorer}/token/${trade.collateralToken}|${tokenName}> of *${outcome}* ${type} in "<https://omen.eth.link/#/${trade.fpmm}|${trade.title}>".`,
             `> Outcome odds: ${oldOdds}% --> ${odds}%`,
             `> *Created by*: <https://omen.eth.link/#/${trade.creator}|${truncate(trade.creator, 14)}>`,
+            `> *Transaction*: <https://${urlExplorer}/tx/${trade.transactionHash}|${truncate(trade.transactionHash, 14)}>`,
         );
         // Send Slack notification
         pushSlackArrayMessages(message);

--- a/src/index.js
+++ b/src/index.js
@@ -27,21 +27,8 @@ const startMessage = `Conditional Tokens bot \`${packageJson.version}\` was star
 pushSlackMessage(startMessage);
 console.log(startMessage);
 
-// Watch new market created and resolved market events
-let lastUsedBlock = 0;
-schedule.scheduleJob(`*/${jobTime} * * * *`, function() {
-    const fromBlock = lastUsedBlock ? lastUsedBlock : 0;
-    watchCreationMarketsEvent(fromBlock).then(toBlock => {
-        lastUsedBlock = toBlock;
-    });
-    // Watch resolved markets
-    watchResolvedMarketsEvent(fromBlock);
-
-    // Watch Realitio events
-    findLogNotifyOfArbitrationRequestArbitration(fromBlock);
-});
-
-console.log(`Configure to find trade, liquidity events and market ready to be resolved for every ${jobTime} minutes`);
+console.log(`Configure to find events every ${jobTime} minutes`);
+let fromBlock = 0;
 const pastTimeInSeconds = jobTime * 60;
 schedule.scheduleJob(`*/${jobTime} * * * *`, async () => {
     // Calculate from and to bock numbers

--- a/src/index.js
+++ b/src/index.js
@@ -27,7 +27,6 @@ const startMessage = `Conditional Tokens bot \`${packageJson.version}\` was star
 pushSlackMessage(startMessage);
 console.log(startMessage);
 
-
 // Watch new market created and resolved market events
 let lastUsedBlock = 0;
 schedule.scheduleJob(`*/${jobTime} * * * *`, function() {

--- a/src/index.js
+++ b/src/index.js
@@ -27,8 +27,22 @@ const startMessage = `Conditional Tokens bot \`${packageJson.version}\` was star
 pushSlackMessage(startMessage);
 console.log(startMessage);
 
-console.log(`Configure to find events every ${jobTime} minutes`);
-let fromBlock = 0;
+
+// Watch new market created and resolved market events
+let lastUsedBlock = 0;
+schedule.scheduleJob(`*/${jobTime} * * * *`, function() {
+    const fromBlock = lastUsedBlock ? lastUsedBlock : 0;
+    watchCreationMarketsEvent(fromBlock).then(toBlock => {
+        lastUsedBlock = toBlock;
+    });
+    // Watch resolved markets
+    watchResolvedMarketsEvent(fromBlock);
+
+    // Watch Realitio events
+    findLogNotifyOfArbitrationRequestArbitration(fromBlock);
+});
+
+console.log(`Configure to find trade, liquidity events and market ready to be resolved for every ${jobTime} minutes`);
 const pastTimeInSeconds = jobTime * 60;
 schedule.scheduleJob(`*/${jobTime} * * * *`, async () => {
     // Calculate from and to bock numbers

--- a/src/services/getLiquidity.js
+++ b/src/services/getLiquidity.js
@@ -12,7 +12,7 @@ const fetch = require('node-fetch');
  * @returns a FPMM liquidity list with the ffpm and funder addresses.
  */
 module.exports.getLiquidity = (creationTimestamp, seconds, limit) => {
-  const jsonQuery = { query: `{fpmmLiquidities(first: ${limit}, where: { creationTimestamp_gt: \"${creationTimestamp-seconds}\", creationTimestamp_lte: \"${creationTimestamp}\" }, orderBy: creationTimestamp, orderDirection: desc) { id fpmm { id title scaledLiquidityParameter collateralToken } funder { id } type outcomeTokenAmounts collateralTokenAmount additionalLiquidityParameter sharesAmount collateralRemovedFromFeePool creationTimestamp }}` };
+  const jsonQuery = { query: `{fpmmLiquidities(first: ${limit}, where: { creationTimestamp_gt: \"${creationTimestamp-seconds}\", creationTimestamp_lte: \"${creationTimestamp}\" }, orderBy: creationTimestamp, orderDirection: desc) { id fpmm { id title scaledLiquidityParameter collateralToken } funder { id } type outcomeTokenAmounts collateralTokenAmount additionalLiquidityParameter sharesAmount collateralRemovedFromFeePool creationTimestamp transactionHash }}` };
   const promise = fetch(process.env.THE_GRAPH_OMEN, {
     headers: {'Content-Type': 'application/json'},
     body: JSON.stringify(jsonQuery),
@@ -38,6 +38,7 @@ module.exports.getLiquidity = (creationTimestamp, seconds, limit) => {
         sharesAmount: liquidity.sharesAmount,
         collateralRemovedFromFeePool: liquidity.collateralRemovedFromFeePool,
         creationTimestamp: liquidity.creationTimestamp,
+        transactionHash: liquidity.transactionHash,
       })
     );
   });

--- a/src/services/getTrade.js
+++ b/src/services/getTrade.js
@@ -12,7 +12,7 @@ const fetch = require('node-fetch');
  * @returns a FPMM Trade list with the ffpm addres and the outcomes.
  */
 module.exports.getTrade = (creationTimestamp, seconds, limit) => {
-  const jsonQuery = { query: `{fpmmTrades(first: ${limit}, where: { creationTimestamp_gt: \"${creationTimestamp-seconds}\", creationTimestamp_lte: \"${creationTimestamp}\" }, orderBy: creationTimestamp, orderDirection: desc) { id fpmm { id outcomes outcomeTokenMarginalPrices } creator { id } title collateralToken collateralAmount collateralAmountUSD feeAmount type creationTimestamp outcomeIndex outcomeTokensTraded }}` }
+  const jsonQuery = { query: `{fpmmTrades(first: ${limit}, where: { creationTimestamp_gt: \"${creationTimestamp-seconds}\", creationTimestamp_lte: \"${creationTimestamp}\" }, orderBy: creationTimestamp, orderDirection: desc) { id fpmm { id outcomes } creator { id } title collateralToken outcomeTokenMarginalPrice oldOutcomeTokenMarginalPrice collateralAmount collateralAmountUSD feeAmount type creationTimestamp outcomeIndex outcomeTokensTraded transactionHash }}` }
 
   const promise = fetch(process.env.THE_GRAPH_OMEN, {
     headers: {'Content-Type': 'application/json'},
@@ -28,9 +28,12 @@ module.exports.getTrade = (creationTimestamp, seconds, limit) => {
       ({
         id: trade.id,
         fpmm: trade.fpmm.id,
+        outcomes: trade.fpmm.outcomes,
         title: trade.title,
         collateralToken: trade.collateralToken,
         collateralAmount: trade.collateralAmount,
+        outcomeTokenMarginalPrice: trade.outcomeTokenMarginalPrice,
+        oldOutcomeTokenMarginalPrice: trade.oldOutcomeTokenMarginalPrice,
         collateralAmountUSD: trade.collateralAmountUSD,
         feeAmount: trade.feeAmount,
         type: trade.type,
@@ -38,8 +41,7 @@ module.exports.getTrade = (creationTimestamp, seconds, limit) => {
         creationTimestamp: trade.creationTimestamp,
         outcomeIndex: trade.outcomeIndex,
         outcomeTokensTraded: trade.outcomeTokensTraded,
-        outcomes: trade.fpmm.outcomes,
-        outcomeTokenMarginalPrices: trade.fpmm.outcomeTokenMarginalPrices
+        transactionHash: trade.transactionHash,
       })
     );
   });


### PR DESCRIPTION
- Update the FPMMTrade query adding added atrributes
`outcomeTokenMarginalPrice`, `oldOutcomeTokenMarginalPrice`,
and `transactionHash`.
- Add `transactionHash` to Trade message events.
- Add `transactionHash` to Liquidity message events.

Resolves: #46, #42 