### PR TITLE
Fix liquidity messages before new Markets

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,8 +6,9 @@ The bot supports `mainnet` and `rinkeby` Ethereum networks.
 
 ## Configure
 
-- **NETWORK_NAME**: THe Ethereum network name.
 - **ETH_NODE**: The Ethereum websocket to watch contracts.
+- **BLOCK_REORG_LIMIT**: Previous number of blocks to process to avoid reorgs.
+- **AVERAGE_BLOCK_TIME**: Average block time to look for previous blocks on timestamp queries.
 - **CT_ADDRESS**: The Conditional Tokens contract address for resolved markets events.
 - **FIXED_PRODUCT_MM_FACTORY_ADDRESS**: The Fixed Product Market Maker factory contract address for new markets creation events.
 - **REALITIO_CONTRACT_ADDRESS**: The Realitio contract address for arbitration requests notification events.

--- a/src/config/constants.js
+++ b/src/config/constants.js
@@ -1,8 +1,0 @@
-const { networkName } = require('./index');
-
-const urlExplorer = (networkName == "rinkeby") ? 'rinkeby.etherscan.io' : 'etherscan.io';
-
-module.exports = {
-    networkName,
-    urlExplorer,
-}

--- a/src/config/index.js
+++ b/src/config/index.js
@@ -4,7 +4,8 @@ dotenv.config();
 module.exports = {
   port: process.env.PORT ? process.env.PORT : 3000,
   slackUrl: process.env.SLACK_WEBHOOK_URL,
-  networkName: process.env.NETWORK_NAME,
   network: process.env.ETH_NODE,
+  blockReorgLimit: process.env.BLOCK_REORG_LIMIT ? process.env.BLOCK_REORG_LIMIT : 5,
+  averageBlockTime: process.env.AVERAGE_BLOCK_TIME ? process.env.AVERAGE_BLOCK_TIME : 20,
   jobTime: process.env.JOB_GET_TRADE_MINUTES ? process.env.JOB_GET_TRADE_MINUTES : 5,
 }

--- a/src/events/liquidityEvents.js
+++ b/src/events/liquidityEvents.js
@@ -1,9 +1,8 @@
-const { urlExplorer } = require('../config/constants');
 const { truncate } = require('../utils/utils');
 const { pushSlackArrayMessages } = require('../utils/slack');
 const { getTokenName, getTokenSymbol, getTokenDecimals } = require('../services/contractERC20');
 const { getLiquidity } = require('../services/getLiquidity');
-const { web3 } = require('../utils/web3');
+const { getUrlExplorer, web3 } = require('../utils/web3');
 
 /**
  * Look for last FPMM liquidity records ordered by `creationTimestamp`.
@@ -15,6 +14,8 @@ const { web3 } = require('../utils/web3');
  */
 module.exports.findLiquidityEvents = async (timestamp, pastTimeInSeconds) => {
     console.log(`Looking for new liquidity at ${timestamp}`);
+    const urlExplorer = await getUrlExplorer();
+
     getLiquidity(timestamp, pastTimeInSeconds, 20)
         .then(liquidities => {
             liquidities.forEach(liquidity => {
@@ -27,7 +28,7 @@ module.exports.findLiquidityEvents = async (timestamp, pastTimeInSeconds) => {
                     .then(([tokenName, tokenSymbol, decimals]) => {
                         const type = (liquidity.type === 'Add') ? 'added' : 'removed';
                         const amount = parseFloat(liquidity.collateralTokenAmount / 10**decimals).toFixed(2);
-                        message.push(`> ${amount} <https://${urlExplorer}/token/${liquidity.collateralToken}|${tokenName}> of liquidity ${type} in "*<https://omen.eth.link/#/${liquidity.fpmm}|${liquidity.title}>*", total liquidity is now *${liquidity.scaledLiquidityParameter} ${tokenSymbol}*.`,
+                        message.push(`> ${amount} <${urlExplorer}/token/${liquidity.collateralToken}|${tokenName}> of liquidity ${type} in "*<https://omen.eth.link/#/${liquidity.fpmm}|${liquidity.title}>*", total liquidity is now *${liquidity.scaledLiquidityParameter} ${tokenSymbol}*.`,
                             `> *Created by*: <https://omen.eth.link/#/${liquidity.funder}|${truncate(liquidity.funder, 14)}>`,
                         );
                         // Send Slack notification

--- a/src/events/realitioEvents.js
+++ b/src/events/realitioEvents.js
@@ -1,3 +1,4 @@
+const { blockReorgLimit } = require('../config');
 const { pushSlackArrayMessages } = require('../utils/slack');
 const { web3, getLastBlockNumber } = require('../utils/web3');
 const { getRealitioContract } = require('../services/contractEvents');
@@ -42,10 +43,11 @@ const getRealitioLogNotifyOfArbitrationRequestEvent = async (fromBlock, toBlock)
  * @param fromBlock 
  */
 module.exports.findLogNotifyOfArbitrationRequestArbitration = async (fromBlock) => {
+    const lastBlock = await getLastBlockNumber();
     if (fromBlock === 0) {
-        fromBlock = await getLastBlockNumber() - 10;
+        fromBlock = lastBlock - (blockReorgLimit * 2);
     }
-    const toBlock = await getLastBlockNumber() - 5;
+    const toBlock = lastBlock - blockReorgLimit;
     getRealitioLogNotifyOfArbitrationRequestEvent(fromBlock, toBlock);
     return (toBlock + 1);
 }

--- a/src/events/tradeEvents.js
+++ b/src/events/tradeEvents.js
@@ -1,7 +1,6 @@
-const { urlExplorer } = require('../config/constants');
 const { truncate } = require('../utils/utils');
 const { pushSlackArrayMessages } = require('../utils/slack');
-const { web3 } = require('../utils/web3');
+const { getUrlExplorer, web3 } = require('../utils/web3');
 const { getTokenName, getTokenDecimals } = require('../services/contractERC20');
 const { getTrade, getOldTrade } = require('../services/getTrade');
 
@@ -15,7 +14,9 @@ const { getTrade, getOldTrade } = require('../services/getTrade');
  */
 module.exports.findTradeEvents = async (timestamp, pastTimeInSeconds) => {
     console.log(`Looking for new trades at ${timestamp}`);
-    const trades = await getTrade(timestamp, pastTimeInSeconds, 20)
+    const trades = await getTrade(timestamp, pastTimeInSeconds, 20);
+    const urlExplorer = await getUrlExplorer();
+
     for (const trade of trades) {
         const message = new Array();
         const type = (trade.type === 'Buy') ? 'purchased' : 'sold';
@@ -29,7 +30,7 @@ module.exports.findTradeEvents = async (timestamp, pastTimeInSeconds) => {
         }
         const oldOdds = (oldTrade && oldTrade.outcomeTokenMarginalPrices) ? parseFloat(oldTrade.outcomeTokenMarginalPrices[trade.outcomeIndex] * 100 ).toFixed(2) : '0.00';
         const outcome = trade.outcomes ? trade.outcomes[trade.outcomeIndex] : trade.outcomeIndex;
-        message.push(`> ${amount} <https://${urlExplorer}/token/${trade.collateralToken}|${tokenName}> of *${outcome}* ${type} in "<https://omen.eth.link/#/${trade.fpmm}|${trade.title}>".`,
+        message.push(`> ${amount} <${urlExplorer}/token/${trade.collateralToken}|${tokenName}> of *${outcome}* ${type} in "<https://omen.eth.link/#/${trade.fpmm}|${trade.title}>".`,
             `> Outcome odds: ${oldOdds}% --> ${odds}%`,
             `> *Created by*: <https://omen.eth.link/#/${trade.creator}|${truncate(trade.creator, 14)}>`,
         );

--- a/src/utils/web3.js
+++ b/src/utils/web3.js
@@ -4,12 +4,47 @@ const { network } = require('../config');
 
 // Create a web3 instance
 const web3 = new Web3(new Web3.providers.HttpProvider(network));
+const chainId = web3.eth.getChainId();
 
+/**
+ * Get network id
+ */
+const getChainId = async () => {
+    return await chainId;
+}
+
+/**
+ * Get Ethereum urlExplorer
+ */
+const getUrlExplorer = async () => {
+    const protocol = 'https'
+    const explorer = 'etherscan.io';
+    const chainId = await getChainId();
+
+    console.log(`netwrok id ${chainId}`);
+
+    switch (chainId) {
+        case 1: return `${protocol}://${explorer}`;
+            break;
+        case 4: return `${protocol}://rinkeby.${explorer}`
+            break;
+        default:
+            return `${protocol}://${explorer}`;
+    }
+}
+
+/**
+ * Get last block number
+ */
 const getLastBlockNumber = async () => {
     return web3.eth.getBlockNumber();
 }
 
+
+
 module.exports = {
     web3,
+    getChainId,
+    getUrlExplorer,
     getLastBlockNumber,
 }


### PR DESCRIPTION
- Merge schedule for watching contract events and thegraph queries.
- Add `averageBlockTime` to look for the `toBlock` block number on get
  previous events.
- Add await operator for call function events.
- Remove constants and add new env variables.
- Add `getChainId` and `getUrlExplorer` to web3 util.
- Add new Ethereum configuration enviroments: `AVERAGE_BLOCK_TIME` and `BLOCK_REORG_LIMIT`.

Resolves: #37
