### PR TITLE
Fix watch events fromBlock greather than toBlock

### DIFF
--- a/src/events/realitioEvents.js
+++ b/src/events/realitioEvents.js
@@ -1,20 +1,19 @@
-const { blockReorgLimit } = require('../config');
 const { pushSlackArrayMessages } = require('../utils/slack');
-const { web3, getLastBlockNumber } = require('../utils/web3');
+const { web3 } = require('../utils/web3');
 const { getRealitioContract } = require('../services/contractEvents');
 const { getQuestion } = require('../services/getQuestion');
 
 const realitioContract = getRealitioContract(web3);
 
 /**
- * Get `LogNotifyOfArbitrationRequest` events from a `Realitio` contract.
+ * Watch `LogNotifyOfArbitrationRequest` events from a `Realitio` contract.
  * @param  fromBlock
  * @param  toBlock
  * on the `returnValues` values like the `question_id`,
  * and the `requester` resolver address.
  * 
  */
-const getRealitioLogNotifyOfArbitrationRequestEvent = async (fromBlock, toBlock) => {
+module.exports.watchLogNotifyOfArbitrationRequestArbitration = async (fromBlock, toBlock) => {
     console.log(`Watching realitio LogNotifyOfArbitrationRequest events from ${fromBlock} to ${toBlock} block.`);
 
     realitioContract.getPastEvents('LogNotifyOfArbitrationRequest', {
@@ -22,32 +21,22 @@ const getRealitioLogNotifyOfArbitrationRequestEvent = async (fromBlock, toBlock)
         fromBlock,
         toBlock,
     }, (error, events) => {
-        events.forEach(event => {
-            (async () => {
-                const questions = await getQuestion(event.returnValues.question_id);
-                questions.forEach(question => {
-                    const message = new Array(
-                        '> *Market is in arbitration*',
-                        `> *Title:* <https://omen.eth.link/#/${question.indexedFixedProductMarketMakers}|${question.title}>`,
-                    );
-                    pushSlackArrayMessages(message);
-                    console.log(question.id + ':\n' + message.join('\n') + '\n\n');
-                });
-            })();
-        });
-    })
-}
-
-/**
- * Find a notify of arbitration from Realitio events
- * @param fromBlock 
- */
-module.exports.findLogNotifyOfArbitrationRequestArbitration = async (fromBlock) => {
-    const lastBlock = await getLastBlockNumber();
-    if (fromBlock === 0) {
-        fromBlock = lastBlock - (blockReorgLimit * 2);
-    }
-    const toBlock = lastBlock - blockReorgLimit;
-    getRealitioLogNotifyOfArbitrationRequestEvent(fromBlock, toBlock);
-    return (toBlock + 1);
+        if (error) {
+            console.error(error);
+        } else {
+            for(const event of events) {
+                (async () => {
+                    const questions = await getQuestion(event.returnValues.question_id);
+                    questions.forEach(question => {
+                        const message = new Array(
+                            '> *Market is in arbitration*',
+                            `> *Title:* <https://omen.eth.link/#/${question.indexedFixedProductMarketMakers}|${question.title}>`,
+                        );
+                        pushSlackArrayMessages(message);
+                        console.log(question.id + ':\n' + message.join('\n') + '\n\n');
+                    });
+                })();
+            };
+        }
+    });
 }

--- a/src/index.js
+++ b/src/index.js
@@ -4,10 +4,11 @@ const schedule = require('node-schedule');
 const packageJson = require('../package.json');
 const { port, jobTime, blockReorgLimit, averageBlockTime } = require('./config');
 const { pushSlackMessage } = require('./utils/slack');
+const { getLastBlockNumber } = require('./utils/web3');
 const { watchCreationMarketsEvent, 
     watchResolvedMarketsEvent, 
     findMarketReadyByQuestionOpeningTimestamp } = require('./events/marketEvents');
-const { findLogNotifyOfArbitrationRequestArbitration } = require('./events/realitioEvents');
+const { watchLogNotifyOfArbitrationRequestArbitration } = require('./events/realitioEvents');
 const { findTradeEvents } = require('./events/tradeEvents');
 const { findLiquidityEvents } = require('./events/liquidityEvents');
 
@@ -30,19 +31,26 @@ console.log(startMessage);
 console.log(`Configure to find events every ${jobTime} minutes`);
 let fromBlock = 0;
 const pastTimeInSeconds = jobTime * 60;
-schedule.scheduleJob(`*/${jobTime} * * * *`, async () => {
-        // Watch creation market events
-        fromBlock = await watchCreationMarketsEvent(fromBlock);
-        // Watch resolved market events
-        await watchResolvedMarketsEvent(fromBlock);
-        // Watch Reality.eth events
-        await findLogNotifyOfArbitrationRequestArbitration(fromBlock);
+schedule.scheduleJob(`*/10 */${jobTime} * * * *`, async () => {
+    // Calculate from and to bock numbers
+    const lastBlock = await getLastBlockNumber();
+    const toBlock = lastBlock - blockReorgLimit;
+    if (fromBlock === 0 || fromBlock > toBlock) {
+        fromBlock = toBlock - 752868;
+    }
+    // Watch creation market events
+    await watchCreationMarketsEvent(fromBlock, toBlock);
+    // Watch resolved market events
+    await watchResolvedMarketsEvent(fromBlock, toBlock);
+    // Watch Reality.eth events
+    await watchLogNotifyOfArbitrationRequestArbitration(fromBlock, toBlock);
+    fromBlock = toBlock + 1;
 
-        const timestamp = Math.floor(Date.now() / 1000) - (blockReorgLimit * averageBlockTime);
-        // Find sell/buy Trades
-        await findTradeEvents(timestamp, pastTimeInSeconds);
-        // Find added/removed Liquidities
-        await findLiquidityEvents(timestamp, pastTimeInSeconds);
-        // Find markets ready to be resolved
-        await findMarketReadyByQuestionOpeningTimestamp(timestamp, pastTimeInSeconds);
+    const timestamp = Math.floor(Date.now() / 1000) - (blockReorgLimit * averageBlockTime);
+    // Find sell/buy Trades
+    await findTradeEvents(timestamp, pastTimeInSeconds);
+    // Find added/removed Liquidities
+    await findLiquidityEvents(timestamp, pastTimeInSeconds);
+    // Find markets ready to be resolved
+    await findMarketReadyByQuestionOpeningTimestamp(timestamp, pastTimeInSeconds);
 });

--- a/src/index.js
+++ b/src/index.js
@@ -23,20 +23,19 @@ app.get('/', (req, res) => {
 app.listen(port, () => console.log(`Bot listening on port ${port}!`));
 
 // Start message
-const version = packageJson.version.startsWith('v') ? packageJson.version : `v${packageJson.version}`;
-const startMessage = `Conditional Tokens bot \`${version}\` was started.`;
+const startMessage = `Conditional Tokens bot \`${packageJson.version}\` was started.`;
 pushSlackMessage(startMessage);
 console.log(startMessage);
 
 console.log(`Configure to find events every ${jobTime} minutes`);
 let fromBlock = 0;
 const pastTimeInSeconds = jobTime * 60;
-schedule.scheduleJob(`*/10 */${jobTime} * * * *`, async () => {
+schedule.scheduleJob(`*/${jobTime} * * * *`, async () => {
     // Calculate from and to bock numbers
     const lastBlock = await getLastBlockNumber();
     const toBlock = lastBlock - blockReorgLimit;
     if (fromBlock === 0 || fromBlock > toBlock) {
-        fromBlock = toBlock - 752868;
+        fromBlock = toBlock;
     }
     // Watch creation market events
     await watchCreationMarketsEvent(fromBlock, toBlock);

--- a/src/utils/web3.js
+++ b/src/utils/web3.js
@@ -21,8 +21,6 @@ const getUrlExplorer = async () => {
     const explorer = 'etherscan.io';
     const chainId = await getChainId();
 
-    console.log(`netwrok id ${chainId}`);
-
     switch (chainId) {
         case 1: return `${protocol}://${explorer}`;
             break;


### PR DESCRIPTION
Move the calculate `fromBlock` and `toBlock` numbers to main index App.
Add check if `fromBlock` is zero or greather than `toBlock`.
Add check when there is an error on `getPastEvents`.
Remove the console.log form `getLastBlockNumber`.

Resolves: #49