### PR TITLE
Add escape HTML on title Slack messages

### DIFF
--- a/src/events/liquidityEvents.js
+++ b/src/events/liquidityEvents.js
@@ -1,4 +1,4 @@
-const { truncate } = require('../utils/utils');
+const { truncate, escapeHTML } = require('../utils/utils');
 const { pushSlackArrayMessages } = require('../utils/slack');
 const { getTokenName, getTokenSymbol, getTokenDecimals } = require('../services/contractERC20');
 const { getLiquidity } = require('../services/getLiquidity');
@@ -28,9 +28,9 @@ module.exports.findLiquidityEvents = async (timestamp, pastTimeInSeconds) => {
                     .then(([tokenName, tokenSymbol, decimals]) => {
                         const type = (liquidity.type === 'Add') ? 'added' : 'removed';
                         const amount = parseFloat(liquidity.collateralTokenAmount / 10**decimals).toFixed(2);
-                        message.push(`> ${amount} <${urlExplorer}/token/${liquidity.collateralToken}|${tokenName}> of liquidity ${type} in "*<https://omen.eth.link/#/${liquidity.fpmm}|${liquidity.title}>*", total liquidity is now *${liquidity.scaledLiquidityParameter} ${tokenSymbol}*.`,
+                        message.push(`> ${amount} <${urlExplorer}/token/${liquidity.collateralToken}|${tokenName}> of liquidity ${type} in "*<https://omen.eth.link/#/${liquidity.fpmm}|${escapeHTML(liquidity.title)}>*", total liquidity is now *${liquidity.scaledLiquidityParameter} ${tokenSymbol}*.`,
                             `> *Created by*: <https://omen.eth.link/#/${liquidity.funder}|${truncate(liquidity.funder, 14)}>`,
-                            `> *Transaction*: <https://${urlExplorer}/tx/${liquidity.transactionHash}|${truncate(liquidity.transactionHash, 14)}>`,
+                            `> *Transaction*: <${urlExplorer}/tx/${liquidity.transactionHash}|${truncate(liquidity.transactionHash, 14)}>`,
                         );
                         // Send Slack notification
                         pushSlackArrayMessages(message);

--- a/src/events/marketEvents.js
+++ b/src/events/marketEvents.js
@@ -1,4 +1,4 @@
-const { truncate } = require('../utils/utils');
+const { truncate, escapeHTML } = require('../utils/utils');
 const { pushSlackArrayMessages } = require('../utils/slack');
 const { getChainId, getUrlExplorer, web3 } = require('../utils/web3');
 const { getFixedProductionMarketMakerFactoryContract, getconditionalTokensContract } = require('../services/contractEvents');
@@ -47,13 +47,13 @@ module.exports.watchCreationMarketsEvent = async (fromBlock, toBlock) => {
                                             console.error(`ERROR: Question for hex "${condition.questionId}" not found on contition ID ${event.returnValues.conditionIds[0]}`);
                                         } else {
                                             message.push(questions.map(question => {
-                                                return `> *<https://omen.eth.link/#/${condition.fixedProductMarketMakers}|${question.title}>*\n> *Outcomes:*`;
+                                                return `> *<https://omen.eth.link/#/${condition.fixedProductMarketMakers}|${escapeHTML(question.title)}>*\n> *Outcomes:*`;
                                             }));
                                             message.push(
                                                 (questions.map(question => {
                                                     if (condition.outcomeTokenMarginalPrices) {
                                                             return question.outcomes.map((outcome, i) =>
-                                                                `> \`${(parseFloat(condition.outcomeTokenMarginalPrices[i]) * 100 )
+                                                                `\`${(parseFloat(condition.outcomeTokenMarginalPrices[i]) * 100 )
                                                                     .toFixed(2)}%\` - ${outcome}`
                                                             );
                                                     } else {
@@ -63,7 +63,8 @@ module.exports.watchCreationMarketsEvent = async (fromBlock, toBlock) => {
                                         }
                                         message.push(`> *Collateral*: <${urlExplorer}/token/${event.returnValues.collateralToken}|${tokenName}>`,
                                             `> *Liquidity*: ${parseFloat(condition.scaledLiquidityParameter).toFixed(2)} ${tokenSymbol}`,
-                                            `> *Created by*: <${urlExplorer}/address/${transaction.from}|${truncate(transaction.from, 14)}>`);
+                                            `> *Created by*: <${urlExplorer}/address/${transaction.from}|${truncate(transaction.from, 14)}>`,
+                                            `> *Transaction*: <${urlExplorer}/tx/${transaction.hash}|${truncate(transaction.hash, 14)}>`);
                                             // Send Slack notification
                                         pushSlackArrayMessages(message);
                                         console.log(event.returnValues.conditionIds[0] + ':\n' + message.join('\n') + '\n\n');
@@ -104,7 +105,7 @@ module.exports.watchResolvedMarketsEvent = async (fromBlock, toBlock) => {
                     if (questions.length > 0) {
                         const message = new Array(
                             '> *Market resolved*',
-                            `> *Title:* <https://omen.eth.link/#/${questions[0].indexedFixedProductMarketMakers}|${questions[0].title}>`,
+                            `> *Title:* <https://omen.eth.link/#/${questions[0].indexedFixedProductMarketMakers}|${escapeHTML(questions[0].title)}>`,
                             `> *Answer:*`,
                         );
                         event.returnValues.payoutNumerators.forEach((payout, index) => {
@@ -140,7 +141,7 @@ module.exports.findMarketReadyByQuestionOpeningTimestamp = async (timestamp, pas
             message.push('<!channel>');
         }
         message.push('> *Market ready for resolution*',
-            `> *Title:* <https://omen.eth.link/#/${question.indexedFixedProductMarketMakers}|${question.title}>`,
+            `> *Title:* <https://omen.eth.link/#/${question.indexedFixedProductMarketMakers}|${escapeHTML(question.title)}>`,
         );
         pushSlackArrayMessages(message);
         console.log(question.id + ':\n' + message.join('\n') + '\n\n');

--- a/src/events/realitioEvents.js
+++ b/src/events/realitioEvents.js
@@ -1,3 +1,4 @@
+const { escapeHTML } = require('../utils/utils');
 const { pushSlackArrayMessages } = require('../utils/slack');
 const { web3 } = require('../utils/web3');
 const { getRealitioContract } = require('../services/contractEvents');
@@ -30,7 +31,7 @@ module.exports.watchLogNotifyOfArbitrationRequestArbitration = async (fromBlock,
                     questions.forEach(question => {
                         const message = new Array(
                             '> *Market is in arbitration*',
-                            `> *Title:* <https://omen.eth.link/#/${question.indexedFixedProductMarketMakers}|${question.title}>`,
+                            `> *Title:* <https://omen.eth.link/#/${question.indexedFixedProductMarketMakers}|${escapeHTML(question.title)}>`,
                         );
                         pushSlackArrayMessages(message);
                         console.log(question.id + ':\n' + message.join('\n') + '\n\n');

--- a/src/events/tradeEvents.js
+++ b/src/events/tradeEvents.js
@@ -1,4 +1,4 @@
-const { truncate } = require('../utils/utils');
+const { truncate, escapeHTML } = require('../utils/utils');
 const { pushSlackArrayMessages } = require('../utils/slack');
 const { getUrlExplorer, web3 } = require('../utils/web3');
 const { getTokenName, getTokenDecimals } = require('../services/contractERC20');
@@ -29,10 +29,10 @@ module.exports.findTradeEvents = async (timestamp, pastTimeInSeconds) => {
             message.push('<!here>');
         }
         const outcome = trade.outcomes ? trade.outcomes[trade.outcomeIndex] : trade.outcomeIndex;
-        message.push(`> ${amount} <${urlExplorer}/token/${trade.collateralToken}|${tokenName}> of *${outcome}* ${type} in "<https://omen.eth.link/#/${trade.fpmm}|${trade.title}>".`,
+        message.push(`> ${amount} <${urlExplorer}/token/${trade.collateralToken}|${tokenName}> of *${outcome}* ${type} in "<https://omen.eth.link/#/${trade.fpmm}|${escapeHTML(trade.title)}>".`,
             `> Outcome odds: ${oldOdds}% --> ${odds}%`,
             `> *Created by*: <https://omen.eth.link/#/${trade.creator}|${truncate(trade.creator, 14)}>`,
-            `> *Transaction*: <https://${urlExplorer}/tx/${trade.transactionHash}|${truncate(trade.transactionHash, 14)}>`,
+            `> *Transaction*: <${urlExplorer}/tx/${trade.transactionHash}|${truncate(trade.transactionHash, 14)}>`,
         );
         // Send Slack notification
         pushSlackArrayMessages(message);

--- a/src/utils/utils.js
+++ b/src/utils/utils.js
@@ -23,6 +23,13 @@ const truncate = (fullStr, strLen, separator) => {
            fullStr.substr(fullStr.length - backChars);
 };
 
+const escapeHTML = str => str.replace(/[<>]/g, 
+  tag => ({
+      '<': '&lt;',
+      '>': '&gt;',
+    }[tag]));
+
 module.exports = {
     truncate,
+    escapeHTML,
 }


### PR DESCRIPTION
Add `escapeHTML` utils method to convert `<` and `>` to encode as html.
Remove repeated `https` on some links.

Resolves: #41