### PR TITLE
Fix creator address link and Liquidity amounts

### DIFF
--- a/src/events/liquidityEvents.js
+++ b/src/events/liquidityEvents.js
@@ -27,8 +27,10 @@ module.exports.findLiquidityEvents = async (timestamp, pastTimeInSeconds) => {
                 ])
                     .then(([tokenName, tokenSymbol, decimals]) => {
                         const type = (liquidity.type === 'Add') ? 'added' : 'removed';
-                        const amount = parseFloat(liquidity.collateralTokenAmount / 10**decimals).toFixed(2);
-                        message.push(`> ${amount} <${urlExplorer}/token/${liquidity.collateralToken}|${tokenName}> of liquidity ${type} in "*<https://omen.eth.link/#/${liquidity.fpmm}|${escapeHTML(liquidity.title)}>*", total liquidity is now *${liquidity.scaledLiquidityParameter} ${tokenSymbol}*.`,
+                        const amount = parseFloat(liquidity.collateralTokenAmount / 10**decimals);
+                        const amountToShow = amount > 0.01 ? amount.toFixed(2) : amount.toFixed(decimals/2);
+                        const liquidityScaledToShow = parseFloat(liquidity.scaledLiquidityParameter).toFixed(2);
+                        message.push(`> ${amountToShow} <${urlExplorer}/token/${liquidity.collateralToken}|${tokenName}> of liquidity ${type} in "*<https://omen.eth.link/#/${liquidity.fpmm}|${escapeHTML(liquidity.title)}>*", total liquidity is now *${liquidityScaledToShow} ${tokenSymbol}*.`,
                             `> *Created by*: <${urlExplorer}/address/${liquidity.funder}|${truncate(liquidity.funder, 14)}>`,
                             `> *Transaction*: <${urlExplorer}/tx/${liquidity.transactionHash}|${truncate(liquidity.transactionHash, 14)}>`,
                         );

--- a/src/events/liquidityEvents.js
+++ b/src/events/liquidityEvents.js
@@ -29,7 +29,7 @@ module.exports.findLiquidityEvents = async (timestamp, pastTimeInSeconds) => {
                         const type = (liquidity.type === 'Add') ? 'added' : 'removed';
                         const amount = parseFloat(liquidity.collateralTokenAmount / 10**decimals).toFixed(2);
                         message.push(`> ${amount} <${urlExplorer}/token/${liquidity.collateralToken}|${tokenName}> of liquidity ${type} in "*<https://omen.eth.link/#/${liquidity.fpmm}|${escapeHTML(liquidity.title)}>*", total liquidity is now *${liquidity.scaledLiquidityParameter} ${tokenSymbol}*.`,
-                            `> *Created by*: <https://omen.eth.link/#/${liquidity.funder}|${truncate(liquidity.funder, 14)}>`,
+                            `> *Created by*: <${urlExplorer}/address/${liquidity.funder}|${truncate(liquidity.funder, 14)}>`,
                             `> *Transaction*: <${urlExplorer}/tx/${liquidity.transactionHash}|${truncate(liquidity.transactionHash, 14)}>`,
                         );
                         // Send Slack notification

--- a/src/events/tradeEvents.js
+++ b/src/events/tradeEvents.js
@@ -31,7 +31,7 @@ module.exports.findTradeEvents = async (timestamp, pastTimeInSeconds) => {
         const outcome = trade.outcomes ? trade.outcomes[trade.outcomeIndex] : trade.outcomeIndex;
         message.push(`> ${amount} <${urlExplorer}/token/${trade.collateralToken}|${tokenName}> of *${outcome}* ${type} in "<https://omen.eth.link/#/${trade.fpmm}|${escapeHTML(trade.title)}>".`,
             `> Outcome odds: ${oldOdds}% --> ${odds}%`,
-            `> *Created by*: <https://omen.eth.link/#/${trade.creator}|${truncate(trade.creator, 14)}>`,
+            `> *Created by*: <${urlExplorer}/address/${trade.creator}|${truncate(trade.creator, 14)}>`,
             `> *Transaction*: <${urlExplorer}/tx/${trade.transactionHash}|${truncate(trade.transactionHash, 14)}>`,
         );
         // Send Slack notification


### PR DESCRIPTION
The address for Trade and Liquidity adressses are redirecting to Omen
website. Replace to etherscan address.

Format the liquidity `collateralTokenAmount` and `scaledLiquidityParameter` amounts.

Resolves: #53, #54