### PR TITLE
Add Twitter support

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,10 @@ The bot supports `mainnet` and `rinkeby` Ethereum networks.
 - **CT_ADDRESS**: The Conditional Tokens contract address for resolved markets events.
 - **FIXED_PRODUCT_MM_FACTORY_ADDRESS**: The Fixed Product Market Maker factory contract address for new markets creation events.
 - **REALITIO_CONTRACT_ADDRESS**: The Realitio contract address for arbitration requests notification events.
-- **THE_GRAPH_CONDITIONAL_TOKENS**: The conditional tokens API subgraph endpoint.
 - **THE_GRAPH_OMEN**: The Omen subgraph API endpoint.
 - **SLACK_WEBHOOK_URL** (optional): Your Slack Incomming Webhook endpoint to push messages. If it's not setted the message will be send to the standard output.
+- **TWITTER_CONSUMER_KEY** (optional): The Consumer Twitter Api key.
+- **TWITTER_CONSUMER_SECRET** (optional): The Consumer Twitter Api secret.
+- **TWITTER_ACCESS_TOKEN** (optional): The Twitter API Access Token.
+- **TWITTER_ACCESS_TOKEN_SECRET** (optional): The Twitter API Access Token Secret.
 - **JOB_GET_TRADE_MINUTES** (optional): The number of minutes for the job to ask for new trades on every Market Makers events. Default value `5` minutes.

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "express": "^4.17.1",
     "node-fetch": "^2.6.1",
     "node-schedule": "^1.3.2",
+    "twit": "^2.2.11",
     "web3": "^1.3.0"
   },
   "devDependencies": {

--- a/src/config/index.js
+++ b/src/config/index.js
@@ -4,6 +4,10 @@ dotenv.config();
 module.exports = {
   port: process.env.PORT ? process.env.PORT : 3000,
   slackUrl: process.env.SLACK_WEBHOOK_URL,
+  twitterConsumerKey: process.env.TWITTER_CONSUMER_KEY,
+  twitterConsumerSecret: process.env.TWITTER_CONSUMER_SECRET,
+  twitterAccessToken: process.env.TWITTER_ACCESS_TOKEN,
+  twitterAccessTokenSecret: process.env.TWITTER_ACCESS_TOKEN_SECRET,
   network: process.env.ETH_NODE,
   blockReorgLimit: process.env.BLOCK_REORG_LIMIT ? process.env.BLOCK_REORG_LIMIT : 5,
   averageBlockTime: process.env.AVERAGE_BLOCK_TIME ? process.env.AVERAGE_BLOCK_TIME : 20,

--- a/src/events/liquidityEvents.js
+++ b/src/events/liquidityEvents.js
@@ -1,5 +1,6 @@
-const { truncate, escapeHTML } = require('../utils/utils');
+const { truncate, truncateEnd, escapeHTML } = require('../utils/utils');
 const { pushSlackArrayMessages } = require('../utils/slack');
+const { pushTweetMessages } = require('../utils/twitter');
 const { getTokenName, getTokenSymbol, getTokenDecimals } = require('../services/contractERC20');
 const { getLiquidity } = require('../services/getLiquidity');
 const { getUrlExplorer, web3 } = require('../utils/web3');
@@ -17,8 +18,7 @@ module.exports.findLiquidityEvents = async (timestamp, pastTimeInSeconds) => {
     const urlExplorer = await getUrlExplorer();
 
     const liquidities = await getLiquidity(timestamp, pastTimeInSeconds, 20);
-    for (const liquidity of liquidities) {
-        const message = new Array();
+    for (const liquidity of liquidities) {        
         const tokenName = await getTokenName(web3, liquidity.collateralToken);
         const tokenSymbol = await getTokenSymbol(web3, liquidity.collateralToken);
         const decimals = await getTokenDecimals(web3, liquidity.collateralToken);
@@ -26,13 +26,19 @@ module.exports.findLiquidityEvents = async (timestamp, pastTimeInSeconds) => {
         const amount = parseFloat(liquidity.collateralTokenAmount / 10**decimals);
         const amountToShow = amount > 0.01 ? amount.toFixed(2) : amount.toFixed(decimals/2);
         const liquidityScaledToShow = parseFloat(liquidity.scaledLiquidityParameter).toFixed(2);
-        message.push(`> ${amountToShow} <${urlExplorer}/token/${liquidity.collateralToken}|${tokenName}> of liquidity ${type} in "*<https://omen.eth.link/#/${liquidity.fpmm}|${escapeHTML(liquidity.title)}>*", total liquidity is now *${liquidityScaledToShow} ${tokenSymbol}*.`,
+        const tweetMessage = `${amountToShow} ${tokenSymbol} of liquidity ${type} ` +
+            `in "${truncateEnd(escapeHTML(liquidity.title), 100)}", ` + 
+            `total liquidity is now ${liquidityScaledToShow} ${tokenSymbol}.\n` +
+            `https://omen.eth.link/#/${liquidity.fpmm}`;
+        const slackMessage = new Array(`> ${amountToShow} <${urlExplorer}/token/${liquidity.collateralToken}|${tokenName}> of liquidity ${type} in "*<https://omen.eth.link/#/${liquidity.fpmm}|${escapeHTML(liquidity.title)}>*", total liquidity is now *${liquidityScaledToShow} ${tokenSymbol}*.`,
             `> *Created by*: <${urlExplorer}/address/${liquidity.funder}|${truncate(liquidity.funder, 14)}>`,
             `> *Transaction*: <${urlExplorer}/tx/${liquidity.transactionHash}|${truncate(liquidity.transactionHash, 14)}>`,
         );
         // Send Slack notification
-        pushSlackArrayMessages(message);
+        await pushSlackArrayMessages(slackMessage);
+        // Send Twitter notification
+        await pushTweetMessages(tweetMessage);
         console.log(liquidity.creationTimestamp);
-        console.log(message.join('\n') + '\n');
+        console.log(tweetMessage + '\n');
     }
 }

--- a/src/events/marketEvents.js
+++ b/src/events/marketEvents.js
@@ -1,5 +1,6 @@
-const { truncate, escapeHTML } = require('../utils/utils');
+const { truncate, truncateEnd, escapeHTML } = require('../utils/utils');
 const { pushSlackArrayMessages } = require('../utils/slack');
+const { pushTweetMessages } = require('../utils/twitter');
 const { getChainId, getUrlExplorer, web3 } = require('../utils/web3');
 const { getFixedProductionMarketMakerFactoryContract, getconditionalTokensContract } = require('../services/contractEvents');
 const { getTokenName, getTokenSymbol } = require('../services/contractERC20');
@@ -11,8 +12,8 @@ const conditionalTokensContract = getconditionalTokensContract(web3);
 
 /**
  * Watch `FixedProductMarketMakerCreation` events from a `FixedProductionMarketMakerFactory` contract.
- * @param  fromBlock
- * @param  toBlock
+ * @param fromBlock
+ * @param toBlock
  * on the `returnValues` values like an array with the `conditionIds`,
  * and the `collateralToken`.
  * 
@@ -31,7 +32,7 @@ module.exports.watchCreationMarketsEvent = async (fromBlock, toBlock) => {
         } else {        
             for(const event of events) {
                 (async () => {
-                    const message = new Array('<!here>', '*New market created!* :tada:');
+                    const slackMessage = new Array('<!here>', '*New market created!* :tada:');
                     //TODO support conditional markets
                     const conditions = await getConditionAndQuestions(event.returnValues.conditionIds[0]);
                     const transaction = await web3.eth.getTransaction(event.transactionHash);
@@ -41,25 +42,32 @@ module.exports.watchCreationMarketsEvent = async (fromBlock, toBlock) => {
                         if (!condition.question) {
                             console.error(`ERROR: Question for hex "${condition.questionId}" not found on contition ID ${event.returnValues.conditionIds[0]}`);
                         } else {
-                            message.push(`> *<https://omen.eth.link/#/${condition.fixedProductMarketMakers}|${escapeHTML(condition.question.title)}>*\n> *Outcomes:*`);
+                            const tweetMessage = `New market created!\n` + 
+                                `"${truncateEnd(escapeHTML(condition.question.title), 100)}"\n` +
+                                `https://omen.eth.link/#/${condition.fixedProductMarketMakers}`;
+                            slackMessage.push(`> *<https://omen.eth.link/#/${condition.fixedProductMarketMakers}|${escapeHTML(condition.question.title)}>*\n> *Outcomes:*`);
                             if (condition.outcomeTokenMarginalPrices) {
                                 condition.question.outcomes.map((outcome, i) =>
-                                    message.push(
+                                    slackMessage.push(
                                         `> \`${(parseFloat(condition.outcomeTokenMarginalPrices[i]) * 100)
                                         .toFixed(2)}%\` - ${outcome}`
                                     )
                                 );
                             } else {
-                                message.push(condition.question.outcomes.map(outcome => message.push(`> - ${outcome}`)));
+                                slackMessage.push(condition.question.outcomes.map(outcome => slackMessage.push(`> - ${outcome}`)));
                             }
-                        }
-                        message.push(`> *Collateral*: <${urlExplorer}/token/${event.returnValues.collateralToken}|${tokenName}>`,
-                            `> *Liquidity*: ${parseFloat(condition.scaledLiquidityParameter).toFixed(2)} ${tokenSymbol}`,
-                            `> *Created by*: <${urlExplorer}/address/${transaction.from}|${truncate(transaction.from, 14)}>`,
-                            `> *Transaction*: <${urlExplorer}/tx/${transaction.hash}|${truncate(transaction.hash, 14)}>`);
+                            slackMessage.push(
+                                `> *Collateral*: <${urlExplorer}/token/${event.returnValues.collateralToken}|${tokenName}>`,
+                                `> *Liquidity*: ${parseFloat(condition.scaledLiquidityParameter).toFixed(2)} ${tokenSymbol}`,
+                                `> *Created by*: <${urlExplorer}/address/${transaction.from}|${truncate(transaction.from, 14)}>`,
+                                `> *Transaction*: <${urlExplorer}/tx/${transaction.hash}|${truncate(transaction.hash, 14)}>`
+                            );
                             // Send Slack notification
-                        pushSlackArrayMessages(message);
-                        console.log(event.returnValues.conditionIds[0] + ':\n' + message.join('\n') + '\n\n');
+                            await pushSlackArrayMessages(slackMessage);
+                            // Send Twitter notification
+                            await pushTweetMessages(tweetMessage);
+                            console.log(event.returnValues.conditionIds[0] + ':\n' + tweetMessage + '\n');
+                        }
                     }
                 })();
             };
@@ -69,8 +77,8 @@ module.exports.watchCreationMarketsEvent = async (fromBlock, toBlock) => {
 
 /**
  * Watch `ConditionResolution` events from a `ConditionalTokens` contract.
- * @param  fromBlock
- * @param  toBlock
+ * @param fromBlock
+ * @param toBlock
  * on the `returnValues` returns the following parameters:
  * bytes32 indexed `conditionId` the condition id of the market.
  * address indexed `oracle` the oracle that calls the function `reportPayouts`.
@@ -93,18 +101,23 @@ module.exports.watchResolvedMarketsEvent = async (fromBlock, toBlock) => {
                 (async () => {
                     const questions = await getQuestion(event.returnValues.questionId);
                     if (questions.length > 0) {
-                        const message = new Array(
+                        const tweetMessage = `Market resolved "${truncateEnd(escapeHTML(questions[0].title), 100)}"\n` + 
+                            `https://omen.eth.link/#/${questions[0].indexedFixedProductMarketMakers}`;
+                        const slackMessage = new Array(
                             '> *Market resolved*',
                             `> *Title:* <https://omen.eth.link/#/${questions[0].indexedFixedProductMarketMakers}|${escapeHTML(questions[0].title)}>`,
                             `> *Answer:*`,
                         );
                         event.returnValues.payoutNumerators.forEach((payout, index) => {
                             if(payout === '1') {
-                                message.push(`> - ${questions[0].outcomes[index]}`);
+                                slackMessage.push(`> - ${questions[0].outcomes[index]}`);
                             }
                         });
-                        pushSlackArrayMessages(message);
-                        console.log(event.returnValues.questionId + ':\n' + message.join('\n') + '\n\n');
+                        // Send Slack notification
+                        await pushSlackArrayMessages(slackMessage);
+                        // Send Twitter notification
+                        await pushTweetMessages(tweetMessage);
+                        console.log(event.returnValues.questionId + ':\n' + tweetMessage + '\n');                        
                     } else {
                         console.error(`ERROR: Question for hex "${event.returnValues.questionId}" not found on Omen subgraph.`);
                     }
@@ -115,8 +128,8 @@ module.exports.watchResolvedMarketsEvent = async (fromBlock, toBlock) => {
 }
 
 /**
- * Look for Question records where `openingTimestamp` field is between `timestamp`
- * and `timestamp-pastTimeInSeconds`.
+ * Look for Question records where `openingTimestamp`
+ * field is between `timestamp` and `timestamp-pastTimeInSeconds`.
  * @param timestamp timestamp in seconds to look for Question records.
  * @param pastTimeInSeconds number of seconds to filter the ready Market question.
  */
@@ -124,16 +137,20 @@ module.exports.findMarketReadyByQuestionOpeningTimestamp = async (timestamp, pas
     console.log(`Looking for markets ready to be resolved between ${timestamp-pastTimeInSeconds} and ${timestamp}`);
     const questions = await getQuestionByOpeningTimestamp(timestamp, pastTimeInSeconds, 20);
     const chainId = await getChainId();
-
-    questions.forEach(question => {
-        const message = new Array();
+    for(const question of questions) {
+        const slackMessage = new Array();
         if (chainId === 1) {
-            message.push('<!channel>');
+            slackMessage.push('<!channel>');
         }
-        message.push('> *Market ready for resolution*',
+        const tweetMessage = `Market ready for resolution "${truncateEnd(escapeHTML(question.title), 100)}"\n` + 
+            `https://omen.eth.link/#/${question.indexedFixedProductMarketMakers}`;
+        slackMessage.push('> *Market ready for resolution*',
             `> *Title:* <https://omen.eth.link/#/${question.indexedFixedProductMarketMakers}|${escapeHTML(question.title)}>`,
         );
-        pushSlackArrayMessages(message);
-        console.log(question.id + ':\n' + message.join('\n') + '\n\n');
-    });
+        // Send Slack notification
+        await pushSlackArrayMessages(slackMessage);
+        // Send Twitter notification
+        await pushTweetMessages(tweetMessage);
+        console.log(question.id + ':\n' + tweetMessage + '\n');
+    }
 }

--- a/src/events/tradeEvents.js
+++ b/src/events/tradeEvents.js
@@ -1,7 +1,8 @@
-const { truncate, escapeHTML } = require('../utils/utils');
+const { truncate, truncateEnd, escapeHTML } = require('../utils/utils');
 const { pushSlackArrayMessages } = require('../utils/slack');
+const { pushTweetMessages } = require('../utils/twitter');
 const { getUrlExplorer, web3 } = require('../utils/web3');
-const { getTokenName, getTokenDecimals } = require('../services/contractERC20');
+const { getTokenName, getTokenSymbol, getTokenDecimals } = require('../services/contractERC20');
 const { getTrade, getOldTrade } = require('../services/getTrade');
 
 /**
@@ -18,25 +19,32 @@ module.exports.findTradeEvents = async (timestamp, pastTimeInSeconds) => {
     const urlExplorer = await getUrlExplorer();
 
     for (const trade of trades) {
-        const message = new Array();
+        const slackMessage = new Array();
         const type = (trade.type === 'Buy') ? 'purchased' : 'sold';
         const odds = parseFloat(trade.outcomeTokenMarginalPrice * 100).toFixed(2);
         const oldOdds = parseFloat(trade.oldOutcomeTokenMarginalPrice * 100).toFixed(2);
         const tokenName = await getTokenName(web3, trade.collateralToken);
+        const tokenSymbol = await getTokenSymbol(web3, trade.collateralToken);
         const decimals = await getTokenDecimals(web3, trade.collateralToken);
         const amount = parseFloat(trade.collateralAmount / 10**decimals).toFixed(2);
         if (trade.collateralAmountUSD > 1000.00) {
-            message.push('<!here>');
+            slackMessage.push('<!here>');
         }
         const outcome = trade.outcomes ? trade.outcomes[trade.outcomeIndex] : trade.outcomeIndex;
-        message.push(`> ${amount} <${urlExplorer}/token/${trade.collateralToken}|${tokenName}> of *${outcome}* ${type} in "<https://omen.eth.link/#/${trade.fpmm}|${escapeHTML(trade.title)}>".`,
+        const tweetMessage = `${amount} ${tokenSymbol} of *${outcome}* ${type} ` +
+            `in "${truncateEnd(escapeHTML(trade.title), 100)}".\n` +
+            `Outcome odds: ${oldOdds}% --> ${odds}%\n` +
+            `https://omen.eth.link/#/${trade.fpmm}`;
+        slackMessage.push(`> ${amount} <${urlExplorer}/token/${trade.collateralToken}|${tokenName}> of *${outcome}* ${type} in "<https://omen.eth.link/#/${trade.fpmm}|${escapeHTML(trade.title)}>".`,
             `> Outcome odds: ${oldOdds}% --> ${odds}%`,
             `> *Created by*: <${urlExplorer}/address/${trade.creator}|${truncate(trade.creator, 14)}>`,
             `> *Transaction*: <${urlExplorer}/tx/${trade.transactionHash}|${truncate(trade.transactionHash, 14)}>`,
         );
         // Send Slack notification
-        pushSlackArrayMessages(message);
+        await pushSlackArrayMessages(slackMessage);
+        // Send Twitter notification
+        await pushTweetMessages(tweetMessage);
         console.log(trade.creationTimestamp);
-        console.log(message.join('\n') + '\n');
+        console.log(tweetMessage + '\n');
     }
 }

--- a/src/utils/twitter.js
+++ b/src/utils/twitter.js
@@ -1,0 +1,46 @@
+const Twit = require('twit');
+
+const { 
+  twitterConsumerKey,
+  twitterConsumerSecret,
+  twitterAccessToken,
+  twitterAccessTokenSecret 
+} = require('../config');
+
+let twit;
+if (twitterConsumerKey === undefined || 
+  twitterConsumerSecret === undefined ||
+  twitterAccessToken === undefined ||
+  twitterAccessTokenSecret === undefined
+) {
+  console.log('Twitter API keys are not defined!!');
+} else {
+  twit = new Twit({
+    consumer_key:         twitterConsumerKey,
+    consumer_secret:      twitterConsumerSecret,
+    access_token:         twitterAccessToken,
+    access_token_secret:  twitterAccessTokenSecret,
+    timeout_ms:           60000, // optional HTTP request timeout to apply to all requests.
+    strictSSL:            true,
+  });
+}
+
+/**
+ * Push a tweet from a given `message` text.
+ * @param message the Twitter message text.
+*/
+module.exports.pushTweetMessages = (message) => {
+  if ( message.length > 280 ) {
+    console.error("Twitter is longer than 280 chars");
+    return;
+  }
+  twit && twit.post('statuses/update',
+    { status: message }, 
+    (err, data, response) => {
+      if (err !== undefined) {
+        console.error(err);
+      } else {
+        console.log(`${data.created_at} Tweet sent  ${data.id} with text ${data.text}.`);
+      }
+  });
+}

--- a/src/utils/utils.js
+++ b/src/utils/utils.js
@@ -23,6 +23,15 @@ const truncate = (fullStr, strLen, separator) => {
            fullStr.substr(fullStr.length - backChars);
 };
 
+const truncateEnd = (fullStr, strLen) => {
+    const separator = '...';
+    if (fullStr.length > strLen - 3) {
+        return fullStr.substr(0, strLen) + separator;
+      } else {
+        return fullStr;
+      }
+}
+
 const escapeHTML = str => str.replace(/[<>]/g, 
   tag => ({
       '<': '&lt;',
@@ -31,5 +40,6 @@ const escapeHTML = str => str.replace(/[<>]/g,
 
 module.exports = {
     truncate,
+    truncateEnd,
     escapeHTML,
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -315,7 +315,7 @@ blakejs@^1.1.0:
   resolved "https://registry.yarnpkg.com/blakejs/-/blakejs-1.1.0.tgz#69df92ef953aa88ca51a32df6ab1c54a155fc7a5"
   integrity sha1-ad+S75U6qIylGjLfarHFShVfx6U=
 
-bluebird@^3.5.0:
+bluebird@^3.1.5, bluebird@^3.5.0:
   version "3.7.2"
   resolved "https://registry.yarnpkg.com/bluebird/-/bluebird-3.7.2.tgz#9f229c15be272454ffa973ace0dbee79a1b0c36f"
   integrity sha512-XpNj6GDQzdfW+r2Wnn7xiSAd7TM3jzkxGXBGTtWKuSXv1xUV+azxAm8jdWZN06QTQk+2N2XB9jRDkvbmQmcRtg==
@@ -1467,7 +1467,7 @@ mime-types@^2.1.12, mime-types@^2.1.16, mime-types@~2.1.19, mime-types@~2.1.24:
   dependencies:
     mime-db "1.44.0"
 
-mime@1.6.0:
+mime@1.6.0, mime@^1.3.4:
   version "1.6.0"
   resolved "https://registry.yarnpkg.com/mime/-/mime-1.6.0.tgz#32cd9e5c64553bd58d19a568af452acff04981b1"
   integrity sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg==
@@ -1885,7 +1885,7 @@ readable-stream@^3.6.0:
     string_decoder "^1.1.1"
     util-deprecate "^1.0.1"
 
-request@^2.79.0:
+request@^2.68.0, request@^2.79.0:
   version "2.88.2"
   resolved "https://registry.yarnpkg.com/request/-/request-2.88.2.tgz#d73c918731cb5a87da047e207234146f664d12b3"
   integrity sha512-MsvtOrfG9ZcrOwAW+Qi+F6HbD0CWXEh9ou77uOb7FM2WPhwT7smM833PzanhJLsgXjN89Ir6V2PczXNnMpwKhw==
@@ -2155,6 +2155,15 @@ tweetnacl@^0.14.3, tweetnacl@~0.14.0:
   version "0.14.5"
   resolved "https://registry.yarnpkg.com/tweetnacl/-/tweetnacl-0.14.5.tgz#5ae68177f192d4456269d108afa93ff8743f4f64"
   integrity sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q=
+
+twit@^2.2.11:
+  version "2.2.11"
+  resolved "https://registry.yarnpkg.com/twit/-/twit-2.2.11.tgz#554343d1cf343ddf503280db821f61be5ab407c3"
+  integrity sha512-BkdwvZGRVoUTcEBp0zuocuqfih4LB+kEFUWkWJOVBg6pAE9Ebv9vmsYTTrfXleZGf45Bj5H3A1/O9YhF2uSYNg==
+  dependencies:
+    bluebird "^3.1.5"
+    mime "^1.3.4"
+    request "^2.68.0"
 
 type-is@~1.6.17, type-is@~1.6.18:
   version "1.6.18"


### PR DESCRIPTION
Add support to send the messages in twitter accounts.
Add [twit](https://github.com/ttezel/twit) API Client for node on
`src/utils/twit`.
Add `pushTweetMessages` call for all Omen events.
Add `truncataEnd` for long texts and include in Twitter messages from
the events.